### PR TITLE
fix: update input file paths to be relative in demo code analysis files

### DIFF
--- a/demos/demo-code-analysis.domain-neutral.prompt.md
+++ b/demos/demo-code-analysis.domain-neutral.prompt.md
@@ -9,7 +9,7 @@ description: 'Template to run consistent, security-first code hygiene reviews ac
 ### Metadata
 - Updated: 2025-10-26
 - Source tool: mcp_ai-agent-guid_domain-neutral-prompt-builder
-- Input file: /Users/hahn/LocalDocuments/GitHub_Forks/mcp-ai-agent-guidelines/demos/demo-code-analysis.py
+- Input file: /mcp-ai-agent-guidelines/demos/demo-code-analysis.py
 - Suggested filename: domain-neutral-code-hygiene-review-prompt.prompt.md
 
 # Domain-Neutral Code Hygiene Review Prompt

--- a/demos/demo-code-analysis.guidelines.md
+++ b/demos/demo-code-analysis.guidelines.md
@@ -3,7 +3,7 @@
 ### Metadata
 - Updated: 2025-10-26
 - Source tool: mcp_ai-agent-guid_guidelines-validator
-- Input file: /Users/hahn/LocalDocuments/GitHub_Forks/mcp-ai-agent-guidelines/demos/demo-code-analysis.py
+- Input file: /mcp-ai-agent-guidelines/demos/demo-code-analysis.py
 - Category: workflow
 
 ### 📋 Practice Analysis

--- a/demos/demo-code-analysis.hierarchical.prompt.md
+++ b/demos/demo-code-analysis.hierarchical.prompt.md
@@ -9,7 +9,7 @@ description: 'Produce a step-by-step refactor plan and a checklist'
 ### Metadata
 - Updated: 2025-10-26
 - Source tool: mcp_ai-agent-guid_hierarchical-prompt-builder
-- Input file: /Users/hahn/LocalDocuments/GitHub_Forks/mcp-ai-agent-guidelines/demos/demo-code-analysis.py
+- Input file: /mcp-ai-agent-guidelines/demos/demo-code-analysis.py
 - Suggested filename: produce-a-step-by-step-refactor-plan-and-a-checklist.prompt.md
 
 # Context

--- a/demos/demo-code-analysis.hygiene.md
+++ b/demos/demo-code-analysis.hygiene.md
@@ -3,7 +3,7 @@
 ### Metadata
 - Updated: 2025-10-26
 - Source tool: mcp_ai-agent-guid_code-hygiene-analyzer
-- Input file: /Users/hahn/LocalDocuments/GitHub_Forks/mcp-ai-agent-guidelines/demos/demo-code-analysis.py
+- Input file: /mcp-ai-agent-guidelines/demos/demo-code-analysis.py
 
 ### 📋 Summary
 | Key | Value |


### PR DESCRIPTION
This pull request updates the metadata in several documentation files to standardize the `Input file` path format, removing user-specific absolute paths in favor of project-relative paths. This improves portability and consistency across the documentation.

**Metadata path standardization:**

* Changed the `Input file` field in the metadata section of `demos/demo-code-analysis.domain-neutral.prompt.md`, `demos/demo-code-analysis.guidelines.md`, `demos/demo-code-analysis.hierarchical.prompt.md`, and `demos/demo-code-analysis.hygiene.md` to use the project-relative path `/mcp-ai-agent-guidelines/demos/demo-code-analysis.py` instead of an absolute user directory. [[1]](diffhunk://#diff-35bd870d91ecdfeb9c8eaf08a23aa171a7eda660263f137869b7f692d97c98e8L12-R12) [[2]](diffhunk://#diff-9c992b036c070d8f9cb16c296667bed90210dcc537043eb76f635d1cc89c13cdL6-R6) [[3]](diffhunk://#diff-6dcffb940784375e9ff40a5746844858845e9cfcdbc9c145bdf87865777592deL12-R12) [[4]](diffhunk://#diff-e8dc9f6ab5d82d79dd471b2d1b566e98bc509d0d6b1bc1ae2a4e725128334ea6L6-R6)