### PR TITLE
chore: bump version to 0.7.5 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mcp-ai-agent-guidelines",
-	"version": "0.7.4",
+	"version": "0.7.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mcp-ai-agent-guidelines",
-			"version": "0.7.4",
+			"version": "0.7.5",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mcp-ai-agent-guidelines",
-	"version": "0.7.4",
+	"version": "0.7.5",
 	"description": "A comprehensive Model Context Protocol server providing professional tools, resources, and prompts for implementing AI agent best practices",
 	"main": "dist/index.js",
 	"type": "module",


### PR DESCRIPTION
This pull request includes a minor version bump in the `package.json` file to reflect a new release. No other changes are present.