### PR TITLE
fix: update broken links in references and structured resources

### DIFF
--- a/docs/tips/references.md
+++ b/docs/tips/references.md
@@ -36,7 +36,7 @@ This document formally acknowledges the key references, research, and open-sourc
 The hierarchical prompting approach is fundamental to our prompt builder tools.
 
 - **Learn For Life OT - Prompting Hierarchy**
-  https://learnforlifeot.com.au/resources/f/prompting-hierarchy
+  https://relevanceai.com/prompt-engineering/master-hierarchical-prompting-for-better-ai-interactions
   Educational framework for structured prompting techniques
 
 - **Hierarchical Prompting Taxonomy (arXiv)**

--- a/src/resources/structured.ts
+++ b/src/resources/structured.ts
@@ -1094,7 +1094,7 @@ export const structuredResources: StructuredResource[] = [
 					},
 					{
 						title: "Prompting Hierarchy - Educational Framework",
-						url: "https://learnforlifeot.com.au/resources/f/prompting-hierarchy",
+						url: "https://relevanceai.com/prompt-engineering/master-hierarchical-prompting-for-better-ai-interactions",
 						source: "Learn For Life OT",
 						note: "Visual guide to prompting strategies for learners and practitioners",
 					},


### PR DESCRIPTION
This pull request updates the reference for the "Prompting Hierarchy" resource to point to a more relevant and authoritative source in both the documentation and the structured resources file.

Reference updates:

* Updated the "Prompting Hierarchy" link in `docs/tips/references.md` to use the Relevance AI article instead of the Learn For Life OT website.
* Updated the corresponding URL in `src/resources/structured.ts` to match the new authoritative source.