### PR TITLE
chore: update npm publishing process to use trusted publishers (OIDC) and verify npm version; bump version to 0.12.3

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -316,7 +316,13 @@ jobs:
           cosign sign --yes ${images}
 
   # ============================================================================
-  # Publish to NPM Registry (production)
+  # Publish to NPM Registry (production) - Using Trusted Publishers (OIDC)
+  # See: https://docs.npmjs.com/trusted-publishers
+  # IMPORTANT: Configure trusted publisher on npmjs.com with:
+  #   - Organization/user: Anselmoo
+  #   - Repository: mcp-ai-agent-guidelines
+  #   - Workflow filename: ci-cd.yml
+  #   - Environment: npm (optional but recommended)
   # ============================================================================
   publish-npm:
     name: Publish to NPM 🚀
@@ -328,7 +334,7 @@ jobs:
       url: https://www.npmjs.com/package/mcp-ai-agent-guidelines
     permissions:
       contents: read
-      id-token: write  # for provenance
+      id-token: write  # Required for OIDC trusted publishing
 
     steps:
       - name: Checkout code
@@ -341,8 +347,19 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      # Trusted publishing requires npm 11.5.1+
       - name: Update npm to latest version
         run: npm install -g npm@latest
+
+      - name: Verify npm version
+        run: |
+          NPM_VERSION=$(npm --version)
+          echo "npm version: $NPM_VERSION"
+          # Check if version is at least 11.5.1
+          if [ "$(printf '%s\n' "11.5.1" "$NPM_VERSION" | sort -V | head -n1)" != "11.5.1" ]; then
+            echo "Error: npm version must be at least 11.5.1 for trusted publishing"
+            exit 1
+          fi
 
       - name: Install dependencies
         run: npm ci
@@ -350,8 +367,10 @@ jobs:
       - name: Build package
         run: npm run build
 
+      # Trusted publishing with OIDC - no token needed!
+      # Provenance is automatically generated when using trusted publishers
       - name: Publish to NPM with trusted publisher
-        run: npm publish --provenance --access public
+        run: npm publish --access public
 
   # ============================================================================
   # Create GitHub Release with Signed Artifacts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mcp-ai-agent-guidelines",
-	"version": "0.12.2",
+	"version": "0.12.3",
 	"description": "A comprehensive Model Context Protocol server providing advanced tools, resources, and prompts for implementing AI agent best practices",
 	"main": "dist/index.js",
 	"type": "module",


### PR DESCRIPTION
Enhance the npm publishing process by implementing trusted publishers using OIDC and verifying the npm version. Update the package version to 0.12.3 to reflect these changes. This improves security and ensures compliance with npm's latest publishing standards.

