### PR TITLE
Lower branch coverage threshold from 90 to 85

### DIFF
--- a/.github/workflows/coverage-patch.yml
+++ b/.github/workflows/coverage-patch.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Enforce branch coverage threshold
         run: |
-          node ./scripts/check-branch-coverage.mjs --lcov coverage/lcov.info --threshold 90
+          node ./scripts/check-branch-coverage.mjs --lcov coverage/lcov.info --threshold 85
 
       - name: Compute patch coverage report
         run: |
@@ -45,7 +45,7 @@ jobs:
             --base main \
             --head HEAD \
             --output artifacts/coverage-patch.json \
-            --threshold 90 || true
+            --threshold 85 || true
 
       - name: List artifacts directory (debug)
         run: ls -la artifacts || true


### PR DESCRIPTION
This pull request makes a minor adjustment to the branch and patch coverage thresholds in the GitHub Actions workflow. The coverage threshold required for passing checks has been lowered from 90% to 85%.

- GitHub Actions workflow updates:
  * [`.github/workflows/coverage-patch.yml`](diffhunk://#diff-12be8c3b49bc8ec51fe1c263f32b4ec5cc1a360012b93f835b3f2dcc3a4c7dbfL38-R38): Reduced the branch coverage threshold and patch coverage threshold from 90% to 85% in the relevant workflow steps. [[1]](diffhunk://#diff-12be8c3b49bc8ec51fe1c263f32b4ec5cc1a360012b93f835b3f2dcc3a4c7dbfL38-R38) [[2]](diffhunk://#diff-12be8c3b49bc8ec51fe1c263f32b4ec5cc1a360012b93f835b3f2dcc3a4c7dbfL48-R48)