### PR TITLE
fix: downgrade version to 0.13.1 and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,23 @@
 {
 	"name": "mcp-ai-agent-guidelines",
-	"version": "0.13.2",
+	"version": "0.13.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mcp-ai-agent-guidelines",
-			"version": "0.13.2",
+			"version": "0.13.1",
 			"license": "MIT",
 			"dependencies": {
+				"@chevrotain/cst-dts-gen": "^11.1.1",
+				"@chevrotain/gast": "^11.1.1",
 				"@modelcontextprotocol/sdk": "^1.17.1",
 				"@types/express": "^5.0.3",
 				"cheerio": "^1.1.2",
+				"chevrotain": "^11.1.1",
 				"express": "^5.1.0",
 				"js-yaml": "^4.1.0",
-				"mermaid": "^11.0.0",
+				"mermaid": "^10.9.5",
 				"zod": "^3.25.76"
 			},
 			"bin": {
@@ -35,19 +38,6 @@
 			"engines": {
 				"node": ">=20.0.0",
 				"npm": ">=10.0.0"
-			}
-		},
-		"node_modules/@antfu/install-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
-			"integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
-			"license": "MIT",
-			"dependencies": {
-				"package-manager-detector": "^1.3.0",
-				"tinyexec": "^1.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
@@ -274,60 +264,48 @@
 			}
 		},
 		"node_modules/@braintree/sanitize-url": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
-			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+			"integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
 			"license": "MIT"
 		},
 		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-			"integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.1.tgz",
+			"integrity": "sha512-fRHyv6/f542qQqiRGalrfJl/evD39mAvbJLCekPazhiextEatq1Jx1K/i9gSd5NNO0ds03ek0Cbo/4uVKmOBcw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/gast": "11.0.3",
-				"@chevrotain/types": "11.0.3",
-				"lodash-es": "4.17.21"
+				"@chevrotain/gast": "11.1.1",
+				"@chevrotain/types": "11.1.1",
+				"lodash-es": "4.17.23"
 			}
-		},
-		"node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"license": "MIT"
 		},
 		"node_modules/@chevrotain/gast": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-			"integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.1.tgz",
+			"integrity": "sha512-Ko/5vPEYy1vn5CbCjjvnSO4U7GgxyGm+dfUZZJIWTlQFkXkyym0jFYrWEU10hyCjrA7rQtiHtBr0EaZqvHFZvg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/types": "11.0.3",
-				"lodash-es": "4.17.21"
+				"@chevrotain/types": "11.1.1",
+				"lodash-es": "4.17.23"
 			}
 		},
-		"node_modules/@chevrotain/gast/node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"license": "MIT"
-		},
 		"node_modules/@chevrotain/regexp-to-ast": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-			"integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.1.tgz",
+			"integrity": "sha512-ctRw1OKSXkOrR8VTvOxrQ5USEc4sNrfwXHa1NuTcR7wre4YbjPcKw+82C2uylg/TEwFRgwLmbhlln4qkmDyteg==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/types": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-			"integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.1.tgz",
+			"integrity": "sha512-wb2ToxG8LkgPYnKe9FH8oGn3TMCBdnwiuNC5l5y+CtlaVRbCytU0kbVsk6CGrqTL4ZN4ksJa0TXOYbxpbthtqw==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/utils": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-			"integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.1.tgz",
+			"integrity": "sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -784,23 +762,6 @@
 				"hono": "^4"
 			}
 		},
-		"node_modules/@iconify/types": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-			"license": "MIT"
-		},
-		"node_modules/@iconify/utils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
-			"integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
-			"license": "MIT",
-			"dependencies": {
-				"@antfu/install-pkg": "^1.1.0",
-				"@iconify/types": "^2.0.0",
-				"mlly": "^1.8.0"
-			}
-		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -855,15 +816,6 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
-		"node_modules/@mermaid-js/parser": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
-			"integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
-			"license": "MIT",
-			"dependencies": {
-				"langium": "3.3.1"
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
@@ -1362,192 +1314,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/d3": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-			"integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-array": "*",
-				"@types/d3-axis": "*",
-				"@types/d3-brush": "*",
-				"@types/d3-chord": "*",
-				"@types/d3-color": "*",
-				"@types/d3-contour": "*",
-				"@types/d3-delaunay": "*",
-				"@types/d3-dispatch": "*",
-				"@types/d3-drag": "*",
-				"@types/d3-dsv": "*",
-				"@types/d3-ease": "*",
-				"@types/d3-fetch": "*",
-				"@types/d3-force": "*",
-				"@types/d3-format": "*",
-				"@types/d3-geo": "*",
-				"@types/d3-hierarchy": "*",
-				"@types/d3-interpolate": "*",
-				"@types/d3-path": "*",
-				"@types/d3-polygon": "*",
-				"@types/d3-quadtree": "*",
-				"@types/d3-random": "*",
-				"@types/d3-scale": "*",
-				"@types/d3-scale-chromatic": "*",
-				"@types/d3-selection": "*",
-				"@types/d3-shape": "*",
-				"@types/d3-time": "*",
-				"@types/d3-time-format": "*",
-				"@types/d3-timer": "*",
-				"@types/d3-transition": "*",
-				"@types/d3-zoom": "*"
-			}
-		},
-		"node_modules/@types/d3-array": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-axis": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-			"integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-brush": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-			"integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-chord": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-			"integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-color": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-contour": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-array": "*",
-				"@types/geojson": "*"
-			}
-		},
-		"node_modules/@types/d3-delaunay": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-			"integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-dispatch": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-			"integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-drag": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-			"integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-dsv": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-			"integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-ease": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-fetch": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-			"integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-dsv": "*"
-			}
-		},
-		"node_modules/@types/d3-force": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-format": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-			"integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-geo": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-			"integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/geojson": "*"
-			}
-		},
-		"node_modules/@types/d3-hierarchy": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-			"integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-interpolate": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-color": "*"
-			}
-		},
-		"node_modules/@types/d3-path": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-polygon": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-			"integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-quadtree": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-			"integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-random": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-			"integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-			"license": "MIT"
-		},
 		"node_modules/@types/d3-scale": {
 			"version": "4.0.9",
 			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -1563,56 +1329,19 @@
 			"integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
 			"license": "MIT"
 		},
-		"node_modules/@types/d3-selection": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-			"integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-shape": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-path": "*"
-			}
-		},
 		"node_modules/@types/d3-time": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
 			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
 			"license": "MIT"
 		},
-		"node_modules/@types/d3-time-format": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-			"integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-timer": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-transition": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-			"integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+		"node_modules/@types/debug": {
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+			"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-zoom": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-			"integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-interpolate": "*",
-				"@types/d3-selection": "*"
+				"@types/ms": "*"
 			}
 		},
 		"node_modules/@types/deep-eql": {
@@ -1652,12 +1381,6 @@
 				"@types/send": "*"
 			}
 		},
-		"node_modules/@types/geojson": {
-			"version": "7946.0.16",
-			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-			"license": "MIT"
-		},
 		"node_modules/@types/http-errors": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -1676,6 +1399,21 @@
 			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
 			"integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/mdast": {
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+			"integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2"
+			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
@@ -1724,6 +1462,12 @@
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/@types/unist": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+			"license": "MIT"
 		},
 		"node_modules/@vitest/coverage-v8": {
 			"version": "4.0.18",
@@ -1878,18 +1622,6 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -2177,6 +1909,16 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/cheerio": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
@@ -2220,36 +1962,18 @@
 			}
 		},
 		"node_modules/chevrotain": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-			"integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.1.tgz",
+			"integrity": "sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/cst-dts-gen": "11.0.3",
-				"@chevrotain/gast": "11.0.3",
-				"@chevrotain/regexp-to-ast": "11.0.3",
-				"@chevrotain/types": "11.0.3",
-				"@chevrotain/utils": "11.0.3",
-				"lodash-es": "4.17.21"
+				"@chevrotain/cst-dts-gen": "11.1.1",
+				"@chevrotain/gast": "11.1.1",
+				"@chevrotain/regexp-to-ast": "11.1.1",
+				"@chevrotain/types": "11.1.1",
+				"@chevrotain/utils": "11.1.1",
+				"lodash-es": "4.17.23"
 			}
-		},
-		"node_modules/chevrotain-allstar": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-			"integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-			"license": "MIT",
-			"dependencies": {
-				"lodash-es": "^4.17.21"
-			},
-			"peerDependencies": {
-				"chevrotain": "^11.0.0"
-			}
-		},
-		"node_modules/chevrotain/node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"license": "MIT"
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -2374,12 +2098,6 @@
 			"engines": {
 				"node": ">=20"
 			}
-		},
-		"node_modules/confbox": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-			"license": "MIT"
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.1",
@@ -2516,33 +2234,6 @@
 			"peerDependencies": {
 				"cytoscape": "^3.2.0"
 			}
-		},
-		"node_modules/cytoscape-fcose": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
-			"integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
-			"license": "MIT",
-			"dependencies": {
-				"cose-base": "^2.2.0"
-			},
-			"peerDependencies": {
-				"cytoscape": "^3.2.0"
-			}
-		},
-		"node_modules/cytoscape-fcose/node_modules/cose-base": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
-			"integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
-			"license": "MIT",
-			"dependencies": {
-				"layout-base": "^2.0.0"
-			}
-		},
-		"node_modules/cytoscape-fcose/node_modules/layout-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
-			"integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-			"license": "MIT"
 		},
 		"node_modules/d3": {
 			"version": "7.9.0",
@@ -3037,6 +2728,19 @@
 				}
 			}
 		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/degenerator": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -3068,6 +2772,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/diff": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+			"integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dom-serializer": {
@@ -3160,6 +2882,12 @@
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
 			"license": "MIT"
+		},
+		"node_modules/elkjs": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+			"integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+			"license": "EPL-2.0"
 		},
 		"node_modules/emoji-regex": {
 			"version": "9.2.2",
@@ -3693,12 +3421,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/hachure-fill": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
-			"integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
-			"license": "MIT"
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4061,20 +3783,13 @@
 			"resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
 			"integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
 		},
-		"node_modules/langium": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
-			"integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
+		"node_modules/kleur": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
 			"license": "MIT",
-			"dependencies": {
-				"chevrotain": "~11.0.3",
-				"chevrotain-allstar": "~0.3.0",
-				"vscode-languageserver": "~9.0.1",
-				"vscode-languageserver-textdocument": "~1.0.11",
-				"vscode-uri": "~3.0.8"
-			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=6"
 			}
 		},
 		"node_modules/layout-base": {
@@ -4384,6 +4099,43 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/mdast-util-from-markdown": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+			"integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"mdast-util-to-string": "^3.1.0",
+				"micromark": "^3.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-decode-string": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"uvu": "^0.5.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-string": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+			"integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/media-typer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -4406,44 +4158,474 @@
 			}
 		},
 		"node_modules/mermaid": {
-			"version": "11.12.2",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.2.tgz",
-			"integrity": "sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==",
+			"version": "10.9.5",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.9.5.tgz",
+			"integrity": "sha512-eRlKEjzak4z1rcXeCd1OAlyawhrptClQDo8OuI8n6bSVqJ9oMfd5Lrf3Q+TdJHewi/9AIOc3UmEo8Fz+kNzzuQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@braintree/sanitize-url": "^7.1.1",
-				"@iconify/utils": "^3.0.1",
-				"@mermaid-js/parser": "^0.6.3",
-				"@types/d3": "^7.4.3",
-				"cytoscape": "^3.29.3",
+				"@braintree/sanitize-url": "^6.0.1",
+				"@types/d3-scale": "^4.0.3",
+				"@types/d3-scale-chromatic": "^3.0.0",
+				"cytoscape": "^3.28.1",
 				"cytoscape-cose-bilkent": "^4.1.0",
-				"cytoscape-fcose": "^2.2.0",
-				"d3": "^7.9.0",
+				"d3": "^7.4.0",
 				"d3-sankey": "^0.12.3",
 				"dagre-d3-es": "7.0.13",
-				"dayjs": "^1.11.18",
-				"dompurify": "^3.2.5",
-				"katex": "^0.16.22",
-				"khroma": "^2.1.0",
+				"dayjs": "^1.11.7",
+				"dompurify": "^3.2.4",
+				"elkjs": "^0.9.0",
+				"katex": "^0.16.9",
+				"khroma": "^2.0.0",
 				"lodash-es": "^4.17.21",
-				"marked": "^16.2.1",
-				"roughjs": "^4.6.6",
-				"stylis": "^4.3.6",
+				"mdast-util-from-markdown": "^1.3.0",
+				"non-layered-tidy-tree-layout": "^2.0.2",
+				"stylis": "^4.1.3",
 				"ts-dedent": "^2.2.0",
-				"uuid": "^11.1.0"
+				"uuid": "^9.0.0",
+				"web-worker": "^1.2.0"
 			}
 		},
-		"node_modules/mermaid/node_modules/marked": {
-			"version": "16.4.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+		"node_modules/micromark": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+			"integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
 			"license": "MIT",
-			"bin": {
-				"marked": "bin/marked.js"
-			},
-			"engines": {
-				"node": ">= 20"
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-core-commonmark": "^1.0.1",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-combine-extensions": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-sanitize-uri": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
 			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+			"integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-factory-destination": "^1.0.0",
+				"micromark-factory-label": "^1.0.0",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-factory-title": "^1.0.0",
+				"micromark-factory-whitespace": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-classify-character": "^1.0.0",
+				"micromark-util-html-tag-name": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+			"integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+			"integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+			"integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+			"integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+			"integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+			"integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+			"integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+			"integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+			"integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+			"integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-string": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+			"integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+			"integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+			"integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+			"integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+			"integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+			"integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+			"integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+			"integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+			"integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/mime-db": {
 			"version": "1.54.0",
@@ -4496,16 +4678,13 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/mlly": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+		"node_modules/mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
 			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.15.0",
-				"pathe": "^2.0.3",
-				"pkg-types": "^1.3.1",
-				"ufo": "^1.6.1"
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/ms": {
@@ -4582,6 +4761,12 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
+		},
+		"node_modules/non-layered-tidy-tree-layout": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+			"integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
+			"license": "MIT"
 		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",
@@ -4721,12 +4906,6 @@
 			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
-		"node_modules/package-manager-detector": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-			"integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-			"license": "MIT"
-		},
 		"node_modules/parse5": {
 			"version": "7.3.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -4785,12 +4964,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/path-data-parser": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
-			"integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
-			"license": "MIT"
-		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4848,6 +5021,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/picocolors": {
@@ -4877,33 +5051,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/pkg-types": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-			"license": "MIT",
-			"dependencies": {
-				"confbox": "^0.1.8",
-				"mlly": "^1.7.4",
-				"pathe": "^2.0.1"
-			}
-		},
-		"node_modules/points-on-curve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
-			"integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
-			"license": "MIT"
-		},
-		"node_modules/points-on-path": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
-			"integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
-			"license": "MIT",
-			"dependencies": {
-				"path-data-parser": "0.1.0",
-				"points-on-curve": "0.2.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -5110,18 +5257,6 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"node_modules/roughjs": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
-			"integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
-			"license": "MIT",
-			"dependencies": {
-				"hachure-fill": "^0.5.2",
-				"path-data-parser": "^0.1.0",
-				"points-on-curve": "^0.2.0",
-				"points-on-path": "^0.2.1"
-			}
-		},
 		"node_modules/router": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -5143,6 +5278,18 @@
 			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
 			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/sade": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+			"license": "MIT",
+			"dependencies": {
+				"mri": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
@@ -5571,6 +5718,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
 			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -5656,12 +5804,6 @@
 				"node": ">=14.17"
 			}
 		},
-		"node_modules/ufo": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-			"license": "MIT"
-		},
 		"node_modules/undici": {
 			"version": "7.19.2",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-7.19.2.tgz",
@@ -5677,6 +5819,19 @@
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"license": "MIT"
 		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+			"integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -5687,16 +5842,34 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/esm/bin/uuid"
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/uvu": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+			"integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0",
+				"diff": "^5.0.0",
+				"kleur": "^4.0.3",
+				"sade": "^1.7.3"
+			},
+			"bin": {
+				"uvu": "bin.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/v8-to-istanbul": {
@@ -5886,54 +6059,11 @@
 				}
 			}
 		},
-		"node_modules/vscode-jsonrpc": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/vscode-languageserver": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-			"license": "MIT",
-			"dependencies": {
-				"vscode-languageserver-protocol": "3.17.5"
-			},
-			"bin": {
-				"installServerIntoExtension": "bin/installServerIntoExtension"
-			}
-		},
-		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-			"license": "MIT",
-			"dependencies": {
-				"vscode-jsonrpc": "8.2.0",
-				"vscode-languageserver-types": "3.17.5"
-			}
-		},
-		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-			"license": "MIT"
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-			"license": "MIT"
-		},
-		"node_modules/vscode-uri": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-			"license": "MIT"
+		"node_modules/web-worker": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+			"integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/whatwg-encoding": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mcp-ai-agent-guidelines",
-	"version": "0.13.2",
+	"version": "0.13.1",
 	"description": "A comprehensive Model Context Protocol server providing advanced tools, resources, and prompts for implementing AI agent best practices",
 	"main": "dist/index.js",
 	"type": "module",
@@ -115,12 +115,15 @@
 		"vitest": "^4.0.0"
 	},
 	"dependencies": {
+		"@chevrotain/cst-dts-gen": "^11.1.1",
+		"@chevrotain/gast": "^11.1.1",
 		"@modelcontextprotocol/sdk": "^1.17.1",
 		"@types/express": "^5.0.3",
 		"cheerio": "^1.1.2",
+		"chevrotain": "^11.1.1",
 		"express": "^5.1.0",
 		"js-yaml": "^4.1.0",
-		"mermaid": "^11.0.0",
+		"mermaid": "^10.9.5",
 		"zod": "^3.25.76"
 	}
 }


### PR DESCRIPTION
This pull request makes adjustments to the project's dependencies and versioning in `package.json`. The most significant changes involve updating and adding parser-related libraries and reverting the project version.

Dependency updates and additions:

* Added `chevrotain`, `@chevrotain/gast`, and `@chevrotain/cst-dts-gen` as new dependencies, which are libraries for building parsers and working with grammar ASTs.
* Downgraded the `mermaid` dependency from version `11.0.0` to `10.9.5`.

Versioning:

* Reverted the project version from `0.13.2` to `0.13.1` in `package.json`.