### PR TITLE
ci: update CI/CD pipeline and add line ending convention

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['18', '20', '22', '24']  # Test LTS versions (18=EOL, 20/22=active LTS, 24=current)
+        node-version: ['20', '22', '24']  # Test LTS versions (18=EOL, 20/22=active LTS, 24=current)
 
     steps:
       - name: Checkout code

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -128,3 +128,8 @@ symbol_info_budget:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:


### PR DESCRIPTION
Remove Node.js 18 from the CI/CD pipeline and introduce a line ending convention for source files to ensure consistency across different environments.

