### PR TITLE
feat: add build-npm job, upgrade mcp2mcpb to v0.5 with --from-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,28 +122,55 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore
 
+  # ── 2b. Build & pack npm tarball ─────────────────────────────────────────
+  build-npm:
+    name: Build npm package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Build & pack
+        run: npm run build && npm pack --pack-destination dist/
+      - name: Upload npm tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-package
+          path: dist/*.tgz
+          if-no-files-found: error
+
   # ── 3. Build .mcpb bundle ─────────────────────────────────────────────────
   build-mcpb:
     name: Build .mcpb bundle
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: startsWith(github.ref, 'refs/tags/')
+    needs: [build-npm]
     permissions:
       contents: read
 
     steps:
       - uses: actions/checkout@v6
-
+      - name: Download npm package
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-package
+          path: dist/
       - name: Build .mcpb bundle
         id: mcp2mcpb
-        uses: Anselmoo/mcp2mcpb@5e2f399464203530cd84f3e8325fb648de3a6f05 # v0.4.0
+        uses: Anselmoo/mcp2mcpb@v0.5
         with:
           package: mcp-ai-agent-guidelines
           registry: npm
           mode: reference
-          no-probe: "true"
-          attach-to-release: "false"
-
+          from-dist: dist/
+          no-probe: 'true'
+          attach-to-release: 'false'
       - name: Upload .mcpb artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Adds new `build-npm` job: runs `npm run build && npm pack --pack-destination dist/` before bundling, uploading the tarball as `npm-package` artifact
- Upgrades `build-mcpb` job from `Anselmoo/mcp2mcpb@5e2f399` (v0.4.0, registry mode) to `Anselmoo/mcp2mcpb@v0.5` with `from-dist: dist/`
- `build-mcpb` now depends on `build-npm` — bundle is built from the local tarball before/independently of npm publish
- Version is always correct: releasing v0.20.0 produces `mcp-ai-agent-guidelines-0.20.0.mcpb`, read from the tarball's `package.json`
- `github-release` job `needs` and `gh release upload dist/*.mcpb` unchanged

## Test plan

- [ ] CI passes the new `build-npm` and updated `build-mcpb` jobs on this PR
- [ ] On a tag push: verify `github-release` attaches the correctly-versioned `.mcpb` to the GitHub Release
- [ ] Confirm `dist/` in the `build-mcpb` job log shows `*.tgz` before the mcp2mcpb step

🤖 Generated with [Claude Code](https://claude.com/claude-code)