### PR TITLE
fix: pin mcp2mcpb action to SHA b040bab instead of v0.5 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
           path: dist/
       - name: Build .mcpb bundle
         id: mcp2mcpb
-        uses: Anselmoo/mcp2mcpb@v0.5
+        uses: Anselmoo/mcp2mcpb@b040babc466902b721e2367d2e5611908c3603d8
         with:
           package: mcp-ai-agent-guidelines
           registry: npm


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for releases. The only change is updating the `Anselmoo/mcp2mcpb` action to use a specific commit hash instead of a version tag, which can help ensure reproducibility and stability in the CI process.