### PR TITLE
feat: envelope schema versioning policy + headless grounding consumer

### DIFF
--- a/docs/adr/0002-envelope-schema-versioning-policy.md
+++ b/docs/adr/0002-envelope-schema-versioning-policy.md
@@ -1,0 +1,98 @@
+# ADR 0002 — Envelope schema versioning / deprecation policy
+
+- **Status:** Accepted (2026-07-04)
+- **Follows:** ADR 0001 (`docs/adr/0001-remove-sampler-round-trip.md`), follow-up #3
+
+## Context
+
+Workflow tools return their machine-readable result inside a base64 text block
+tagged with a version prefix — the **envelope** (`src/tools/shared/output-envelope.ts`):
+
+```
+__ENVELOPE_V1__:<base64 of { payload, meta }>
+```
+
+`meta` currently carries `{ tool, ts, version }`. Chained agents and tests parse
+this block to read the structured `payload` directly.
+
+ADR 0001 **removed the `situationMode` field** from the workflow envelope (it was
+always `"directive"` once the sampler round-trip was gone). Dropping a
+machine-envelope field is a breaking change for any consumer parsing it, and at
+the time there was **no version-bump signal and no deprecation window** — the
+field simply vanished. Any parser expecting it would silently get `undefined`.
+
+This ADR defines a forward-looking policy so future field removals aren't silent.
+
+## Decision
+
+### 1. One integer version, mirrored in the prefix
+
+The envelope schema is versioned by a single integer, `ENVELOPE_VERSION`, mirrored
+in the text-block prefix `__ENVELOPE_V<n>__:`. The prefix is **derived** from the
+constant (`ENVELOPE_PREFIX`), never hand-typed, so the two can't drift.
+
+### 2. Additive changes do NOT bump the version
+
+Adding a new **optional** field to `payload` or `meta` is backward-compatible and
+does not change the version. Correspondingly, **consumers must ignore unknown
+fields** — `parseEnvelopeBlock` preserves them, and no consumer may treat an
+unexpected field as an error. This is the forward-compatibility half of the
+contract: a v1 parser keeps working against a producer that has added fields.
+
+### 3. Breaking changes require a major version bump
+
+Removing a field, renaming a field, or changing a field's type or semantics is
+breaking. It requires:
+
+- bumping `ENVELOPE_VERSION` (and adding the new version to
+  `SUPPORTED_ENVELOPE_VERSIONS`), which changes the prefix to `__ENVELOPE_V<n+1>__:`; and
+- the deprecation window below for any field being **removed**.
+
+### 4. Deprecation window before removal
+
+A field slated for removal MUST first be announced through the machine-readable
+registry `ENVELOPE_DEPRECATIONS` for **at least one released version** before the
+version that removes it. Each entry is a `FieldDeprecation`:
+
+```ts
+{ field, since, removeInVersion, replacement?, note? }
+```
+
+Producers stamp the active registry into `meta.deprecations` (via
+`buildEnvelopeMeta`), so a consumer parsing today's envelope gets a programmatic
+heads-up — the "capability flag before removals" — instead of discovering the
+loss only when the field is already gone. The registry invariant
+`removeInVersion > ENVELOPE_VERSION` is enforced by test: a field cannot be
+"due for removal" in the very version that still ships it.
+
+`ENVELOPE_DEPRECATIONS` starts **empty** — nothing is deprecated right now.
+`situationMode` was already removed under ADR 0001, before this policy existed;
+it is documented here as the motivating incident, not re-added.
+
+### 5. Parser contract: no silent misparse
+
+`parseEnvelopeBlock` reads the version token from the prefix and:
+
+- throws `not an envelope block` when there is no recognizable prefix;
+- throws `unsupported envelope version <n> …` when the version is real but this
+  consumer does not support it (e.g. a v1 consumer meeting a v2 block), rather
+  than silently failing the `startsWith` check and reporting "not an envelope";
+- otherwise decodes, preserving unknown fields.
+
+## Rationale / Trade-offs
+
+- **Cheap and honest.** The mechanism is a constant, a registry, a `meta` field,
+  and a version-aware parse — no negotiation protocol. The registry being empty
+  reflects reality rather than inventing deprecations to justify the machinery.
+- **Two-sided compatibility.** Additive-changes-are-free + ignore-unknown-fields
+  lets producers and consumers move independently within a major version; the
+  version bump + deprecation window handles the genuinely breaking case.
+- **Trade-off — discipline, not enforcement of the window across releases.** The
+  one-release-minimum window is a policy backed by the registry and the
+  `removeInVersion > ENVELOPE_VERSION` test; it is not automatically enforced
+  against git history. Reviewers uphold the window when approving a removing bump.
+
+## Follow-ups
+
+- When the first real deprecation lands, add its `FieldDeprecation` entry and a
+  test asserting `meta.deprecations` surfaces it end-to-end through a producer.

--- a/evals/fixtures/src/payments/charge.ts
+++ b/evals/fixtures/src/payments/charge.ts
@@ -1,0 +1,6 @@
+// Fixture for the headless workspace-grounding consumer (evals/workspace-grounding-consumer.mjs).
+// Carries a real type-boundary signal (`any`) that qual-code-analysis probes for,
+// so the grounded finding cites this exact path.
+export function charge(amount: any): any {
+	return amount as unknown;
+}

--- a/evals/workspace-grounding-consumer.mjs
+++ b/evals/workspace-grounding-consumer.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Headless / non-LLM consumer of `groundingScope: "workspace"` — issue #1602.
+//
+// Unlike scripts/ab_eval.py (which shells out to a real `claude -p` session),
+// this program has NO model, NO sampler, NO LLM anywhere. It points the REAL
+// filesystem surface `createWorkspaceSurface()` at a checked-in fixture, runs a
+// real skill, and asserts the resulting workspace-grounded findings cite file
+// paths that actually resolve on disk. It exits non-zero if grounding produced
+// nothing citing a real file, so it is a genuine gate, not a demo.
+//
+// Prerequisite: `npm run build` (imports the compiled skill from dist/).
+// Run:          node evals/workspace-grounding-consumer.mjs
+
+import { stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const evalsDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(evalsDir, "..");
+const distSkill = join(repoRoot, "dist/skills/qual/qual-code-analysis.js");
+const distWorkspace = join(
+	repoRoot,
+	"dist/skills/runtime/workspace-adapter.js",
+);
+
+async function loadDist() {
+	try {
+		const [{ skillModule }, { createWorkspaceSurface }] = await Promise.all([
+			import(distSkill),
+			import(distWorkspace),
+		]);
+		return { skillModule, createWorkspaceSurface };
+	} catch (error) {
+		console.error(
+			"✖ Could not import compiled output. Run `npm run build` first.\n ",
+			error instanceof Error ? error.message : String(error),
+		);
+		process.exit(2);
+	}
+}
+
+// Minimal non-LLM runtime: a deterministic model router (no network, no model
+// call) plus the real workspace reader. Mirrors what the MCP server injects.
+function createHeadlessRuntime(workspace) {
+	return {
+		modelRouter: {
+			chooseSkillModel: (manifest) => ({
+				id: "headless-eval",
+				label: "Headless Eval (no model)",
+				modelClass: manifest.preferredModelClass,
+				strengths: ["deterministic grounding"],
+				maxContextWindow: "medium",
+				costTier: manifest.preferredModelClass,
+			}),
+		},
+		workspace,
+	};
+}
+
+async function main() {
+	const { skillModule, createWorkspaceSurface } = await loadDist();
+
+	const fixtureRoot = join(evalsDir, "fixtures");
+	const referencedFile = "src/payments/charge.ts";
+
+	const reader = createWorkspaceSurface(fixtureRoot);
+	const runtime = createHeadlessRuntime(reader);
+
+	const result = await skillModule.run(
+		{ request: `review ${referencedFile} for quality problems` },
+		runtime,
+	);
+
+	const grounded = result.recommendations.filter(
+		(r) => r.groundingScope === "workspace",
+	);
+
+	// Verify every cited path resolves on disk — no model asserted it exists.
+	const findings = [];
+	for (const rec of grounded) {
+		for (const anchor of rec.evidenceAnchors ?? []) {
+			let existsOnDisk = false;
+			try {
+				existsOnDisk = (await stat(join(fixtureRoot, anchor))).isFile();
+			} catch {
+				existsOnDisk = false;
+			}
+			findings.push({ detail: rec.detail, citedPath: anchor, existsOnDisk });
+		}
+	}
+
+	const citingRealFiles = findings.filter((f) => f.existsOnDisk);
+	const report = {
+		question:
+			"Does a non-LLM consumer get workspace-grounded findings that cite real files?",
+		method:
+			"Real createWorkspaceSurface() over evals/fixtures; qual-code-analysis skill; no sampler, no model.",
+		skill: skillModule.manifest.id,
+		referencedFile,
+		groundedFindingCount: grounded.length,
+		findings,
+		citingRealFileCount: citingRealFiles.length,
+		pass: citingRealFiles.length > 0,
+	};
+
+	const outPath = join(evalsDir, "workspace-grounding-results.json");
+	await writeFile(outPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+	console.log(`\nHeadless workspace-grounding consumer (#1602)`);
+	console.log(`  skill:            ${report.skill}`);
+	console.log(`  referenced file:  ${report.referencedFile}`);
+	console.log(`  grounded findings: ${report.groundedFindingCount}`);
+	console.log(`  citing real files: ${report.citingRealFileCount}`);
+	for (const f of findings) {
+		console.log(
+			`   ${f.existsOnDisk ? "✓" : "✗"} ${f.citedPath}  —  ${f.detail}`,
+		);
+	}
+	console.log(`  report: ${outPath}`);
+	console.log(`  result: ${report.pass ? "PASS" : "FAIL"}\n`);
+
+	if (!report.pass) {
+		console.error(
+			"✖ No workspace-grounded finding cited a real on-disk file — the headless-consumer justification would be speculative.",
+		);
+		process.exit(1);
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/evals/workspace-grounding-results.json
+++ b/evals/workspace-grounding-results.json
@@ -1,0 +1,16 @@
+{
+  "question": "Does a non-LLM consumer get workspace-grounded findings that cite real files?",
+  "method": "Real createWorkspaceSurface() over evals/fixtures; qual-code-analysis skill; no sampler, no model.",
+  "skill": "qual-code-analysis",
+  "referencedFile": "src/payments/charge.ts",
+  "groundedFindingCount": 1,
+  "findings": [
+    {
+      "detail": "`src/payments/charge.ts`: Audit type coverage: `any` types, missing return types, and untyped function parameters are defect entry points — strengthen the type boundary before adding features.",
+      "citedPath": "src/payments/charge.ts",
+      "existsOnDisk": true
+    }
+  ],
+  "citingRealFileCount": 1,
+  "pass": true
+}

--- a/evals/workspace-grounding.md
+++ b/evals/workspace-grounding.md
@@ -1,0 +1,59 @@
+# Workspace grounding — real headless / non-LLM consumer
+
+**Issue:** [#1602](https://github.com/Anselmoo/mcp-ai-agent-guidelines/issues/1602) —
+follow-up to ADR 0001 (`docs/adr/0001-remove-sampler-round-trip.md`).
+
+**Question:** ADR 0001 reframed workspace grounding's primary value as serving
+**headless / eval / non-LLM consumers** that can't execute a directive
+themselves. Is that real, or speculative? Does a caller with **no model in the
+loop** actually get problem-specific findings that cite real files?
+
+## Method
+
+A pure Node program — `evals/workspace-grounding-consumer.mjs` — with no
+`claude -p`, no sampler, no model anywhere:
+
+1. Points the **real** filesystem surface `createWorkspaceSurface()` (the same
+   reader the MCP server injects) at the checked-in fixture `evals/fixtures/`.
+2. Runs the real `qual-code-analysis` skill against a request that names a
+   fixture file (`src/payments/charge.ts`, which contains an `any`-typed
+   function — a signal the skill's content probes match).
+3. Collects every `groundingScope: "workspace"` recommendation and verifies each
+   cited path **resolves on disk** (`fs.stat`).
+4. Writes `evals/workspace-grounding-results.json` and **exits non-zero** if no
+   grounded finding cites a real file — so it is a gate, not a demo.
+
+## Result: PASS
+
+The headless consumer gets a workspace-grounded finding that cites the real
+referenced file:
+
+| skill | referenced file | grounded findings | citing real files | result |
+|---|---|---|---|---|
+| `qual-code-analysis` | `src/payments/charge.ts` | 1 | 1 | **PASS** |
+
+> ``src/payments/charge.ts``: Audit type coverage: `any` types, missing return
+> types, and untyped function parameters are defect entry points — strengthen the
+> type boundary before adding features.
+
+The finding is **problem-specific** (derived from the file's real content, citing
+its real path), produced with no model executing the directive. The reframe's
+justification is no longer speculative.
+
+## Reproduce
+
+```bash
+npm run build                             # compiles the skill into dist/
+node evals/workspace-grounding-consumer.mjs
+```
+
+Or run the executable proof / CI gate (no build needed):
+
+```bash
+npx vitest run src/tests/evals/workspace-grounding-consumer.test.ts
+```
+
+That test does the same thing against a freshly-written **temp** workspace (so it
+also proves grounding works for arbitrary real files, not just the checked-in
+fixture) and asserts the cited path exists on disk — no mock `WorkspaceReader`,
+unlike the per-skill grounding unit tests in `src/tests/skills/*/*-grounding.test.ts`.

--- a/src/tests/evals/workspace-grounding-consumer.test.ts
+++ b/src/tests/evals/workspace-grounding-consumer.test.ts
@@ -1,0 +1,85 @@
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { skillModule } from "../../skills/qual/qual-code-analysis.js";
+import { createWorkspaceSurface } from "../../skills/runtime/workspace-adapter.js";
+import { createMockSkillRuntime } from "../skills/test-helpers.js";
+
+/**
+ * Issue #1602 — a REAL headless / non-LLM consumer of `groundingScope: "workspace"`.
+ *
+ * Unlike the per-skill grounding tests (which inject a mock `WorkspaceReader`
+ * returning a canned string), this exercises the *real* filesystem surface
+ * `createWorkspaceSurface()` against *real files on disk* — no mock reader, no
+ * sampler, no model in the loop. It proves the ADR 0001 reframe is not
+ * speculative: a purely headless caller gets problem-specific findings that cite
+ * file paths which actually resolve on disk.
+ */
+
+const RELATIVE_FILE = "src/payments/charge.ts";
+// Content carrying a real type-boundary signal `qual-code-analysis` probes for.
+const FILE_CONTENT =
+	"export function charge(amount: any): any {\n\treturn amount as unknown;\n}\n";
+
+let workspaceRoot: string;
+
+beforeAll(async () => {
+	workspaceRoot = await mkdtemp(join(tmpdir(), "grounding-consumer-"));
+	const absFile = join(workspaceRoot, RELATIVE_FILE);
+	await mkdir(join(workspaceRoot, "src", "payments"), { recursive: true });
+	await writeFile(absFile, FILE_CONTENT, "utf8");
+});
+
+afterAll(async () => {
+	if (workspaceRoot) await rm(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("headless workspace-grounding consumer (#1602)", () => {
+	it("produces workspace-grounded findings that cite a real on-disk file", async () => {
+		// The consumer: real filesystem reader rooted at the temp workspace.
+		const reader = createWorkspaceSurface(workspaceRoot);
+		const runtime = createMockSkillRuntime({ workspace: reader });
+
+		const result = await skillModule.run(
+			{ request: `review ${RELATIVE_FILE} for quality problems` },
+			runtime,
+		);
+
+		const grounded = result.recommendations.filter(
+			(r) => r.groundingScope === "workspace",
+		);
+
+		// 1. Grounding actually fired with no model involved.
+		expect(grounded.length).toBeGreaterThan(0);
+
+		// 2. Every grounded finding cites the referenced path — problem-specific,
+		//    not generic template advice.
+		for (const rec of grounded) {
+			expect(rec.detail).toContain(RELATIVE_FILE);
+			expect(rec.evidenceAnchors).toContain(RELATIVE_FILE);
+		}
+
+		// 3. The crucial non-speculative check: the cited path resolves on disk.
+		const citedPaths = new Set(
+			grounded.flatMap((r) => r.evidenceAnchors ?? []),
+		);
+		for (const cited of citedPaths) {
+			const info = await stat(join(workspaceRoot, cited));
+			expect(info.isFile()).toBe(true);
+		}
+	});
+
+	it("degrades to non-grounded findings when the workspace is absent", async () => {
+		// Same request, no workspace reader — a headless caller with nothing to read
+		// still gets output, just without workspace-scoped citations.
+		const result = await skillModule.run(
+			{ request: `review ${RELATIVE_FILE} for quality problems` },
+			createMockSkillRuntime({}),
+		);
+		expect(
+			result.recommendations.every((r) => r.groundingScope !== "workspace"),
+		).toBe(true);
+		expect(result.recommendations.length).toBeGreaterThan(0);
+	});
+});

--- a/src/tests/tools/shared/output-envelope.test.ts
+++ b/src/tests/tools/shared/output-envelope.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+	buildEnvelopeMeta,
+	ENVELOPE_DEPRECATIONS,
+	ENVELOPE_PREFIX,
+	ENVELOPE_VERSION,
+	type FieldDeprecation,
 	parseEnvelopeBlock,
 	toToolResult,
 } from "../../../tools/shared/output-envelope.js";
@@ -9,16 +14,94 @@ describe("output envelope", () => {
 		const result = toToolResult({
 			summaryMarkdown: "# Hello",
 			payload: { recommendations: [{ id: "r1" }] },
-			meta: {
-				tool: "evidence-research",
-				ts: "2026-06-17T00:00:00Z",
-				version: 1,
-			},
+			meta: buildEnvelopeMeta("evidence-research", "2026-06-17T00:00:00Z"),
 		});
 		expect(result.content[0].text).toBe("# Hello");
 		expect(result.content[1].text).toMatch(/^__ENVELOPE_V1__:/);
 		const parsed = parseEnvelopeBlock(result.content[1].text);
 		expect(parsed.payload).toEqual({ recommendations: [{ id: "r1" }] });
 		expect(parsed.meta.tool).toBe("evidence-research");
+	});
+});
+
+describe("envelope versioning (ADR 0002)", () => {
+	it("derives the prefix from the version constant", () => {
+		expect(ENVELOPE_PREFIX).toBe(`__ENVELOPE_V${ENVELOPE_VERSION}__:`);
+	});
+
+	it("buildEnvelopeMeta stamps the current version", () => {
+		const meta = buildEnvelopeMeta("code-review", "2026-07-04T00:00:00Z");
+		expect(meta).toEqual({
+			tool: "code-review",
+			ts: "2026-07-04T00:00:00Z",
+			version: ENVELOPE_VERSION,
+		});
+	});
+
+	it("omits deprecations from meta while the registry is empty", () => {
+		const meta = buildEnvelopeMeta("code-review", "2026-07-04T00:00:00Z");
+		expect(meta).not.toHaveProperty("deprecations");
+	});
+
+	it("surfaces active deprecations in meta as a capability flag", () => {
+		const sample: FieldDeprecation[] = [
+			{
+				field: "payload.situationMode",
+				since: 1,
+				removeInVersion: 2,
+				replacement: "payload.mode",
+				note: "always 'directive' once sampling was removed",
+			},
+		];
+		const meta = buildEnvelopeMeta(
+			"code-review",
+			"2026-07-04T00:00:00Z",
+			sample,
+		);
+		expect(meta.deprecations).toEqual(sample);
+
+		// Round-trips so a consumer can read the heads-up before the field vanishes.
+		const parsed = parseEnvelopeBlock(
+			toToolResult({ summaryMarkdown: "x", payload: {}, meta }).content[1].text,
+		);
+		expect(parsed.meta.deprecations).toEqual(sample);
+	});
+
+	it("rejects an unsupported (future) envelope version explicitly", () => {
+		const futureBlock = `__ENVELOPE_V2__:${Buffer.from(
+			JSON.stringify({ payload: {}, meta: {} }),
+			"utf8",
+		).toString("base64")}`;
+		expect(() => parseEnvelopeBlock(futureBlock)).toThrow(
+			/unsupported envelope version 2/,
+		);
+	});
+
+	it("rejects a non-envelope block", () => {
+		expect(() => parseEnvelopeBlock("just some text")).toThrow(
+			/not an envelope block/,
+		);
+	});
+
+	it("preserves unknown payload fields (forward-compatible additive change)", () => {
+		// Simulate a newer producer that added an optional field the current
+		// parser doesn't know about. It must survive the round-trip untouched.
+		const block = toToolResult({
+			summaryMarkdown: "x",
+			payload: { known: 1, futureOptionalField: { nested: true } },
+			meta: buildEnvelopeMeta("system-design"),
+		}).content[1].text;
+		const parsed = parseEnvelopeBlock<{
+			known: number;
+			futureOptionalField: { nested: boolean };
+		}>(block);
+		expect(parsed.payload.futureOptionalField).toEqual({ nested: true });
+	});
+
+	it("registry invariant: no field is due for removal in the current version", () => {
+		for (const entry of ENVELOPE_DEPRECATIONS) {
+			expect(entry.removeInVersion).toBeGreaterThan(ENVELOPE_VERSION);
+			expect(entry.removeInVersion).toBeGreaterThan(entry.since);
+		}
 	});
 });

--- a/src/tools/shared/error-handler.ts
+++ b/src/tools/shared/error-handler.ts
@@ -10,7 +10,7 @@ import { err, ok, type Result } from "neverthrow";
 import { match } from "ts-pattern";
 import type { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
-import { toToolResult } from "./output-envelope.js";
+import { buildEnvelopeMeta, toToolResult } from "./output-envelope.js";
 
 // ---------------------------------------------------------------------------
 // Error categories
@@ -107,7 +107,7 @@ export function buildMcpErrorContent(error: McpErrorPayload): {
 	const env = toToolResult({
 		summaryMarkdown: formatMcpError(error),
 		payload: error,
-		meta: { tool: "mcp", ts: new Date().toISOString(), version: 1 },
+		meta: buildEnvelopeMeta("mcp"),
 	});
 	return { isError: true as const, content: env.content };
 }

--- a/src/tools/shared/output-envelope.ts
+++ b/src/tools/shared/output-envelope.ts
@@ -1,12 +1,84 @@
 import type { TextToolResult } from "../tool-call-handler.js";
 
+/**
+ * Current envelope schema version. A single integer, mirrored in the text-block
+ * prefix (`__ENVELOPE_V<n>__:`). See `docs/adr/0002-envelope-schema-versioning-policy.md`
+ * for the bump / deprecation rules.
+ *
+ * Bump this (and add the new version to `SUPPORTED_ENVELOPE_VERSIONS`) only for a
+ * BREAKING change — removing/renaming a field, or changing a field's type or
+ * semantics. Additive changes (a new optional field) do NOT bump the version.
+ */
+export const ENVELOPE_VERSION = 1 as const;
+
+/** Envelope versions this consumer knows how to parse. */
+export const SUPPORTED_ENVELOPE_VERSIONS: readonly number[] = [
+	ENVELOPE_VERSION,
+];
+
+/** Text-block marker for the current envelope version. Derived, never hand-typed. */
+export const ENVELOPE_PREFIX = `__ENVELOPE_V${ENVELOPE_VERSION}__:`;
+
+/**
+ * A payload/meta field that is on its way out. Producers stamp the active set
+ * into `meta.deprecations` so consumers get a machine-readable heads-up BEFORE
+ * the field disappears — the deprecation window that closes the `situationMode`
+ * silent-removal gap (ADR 0001).
+ */
+export interface FieldDeprecation {
+	/** Dotted path of the deprecated field, e.g. `payload.situationMode`. */
+	field: string;
+	/** Version in which the field was first marked deprecated. */
+	since: number;
+	/** Version in which the field is scheduled for removal (must be `> since`). */
+	removeInVersion: number;
+	/** Preferred replacement field, if any. */
+	replacement?: string;
+	/** Free-text migration note. */
+	note?: string;
+}
+
+/**
+ * Central registry of currently-deprecated envelope fields. Intentionally EMPTY:
+ * nothing is deprecated right now (`situationMode` was already removed in ADR
+ * 0001, before this policy existed). New removals MUST land here for at least one
+ * released version before the removing bump — see
+ * `docs/adr/0002-envelope-schema-versioning-policy.md`.
+ */
+export const ENVELOPE_DEPRECATIONS: readonly FieldDeprecation[] = [];
+
 export interface ToolEnvelope<T = unknown> {
 	summaryMarkdown: string;
 	payload: T;
-	meta: { tool: string; ts: string; version: 1 };
+	meta: {
+		tool: string;
+		ts: string;
+		version: number;
+		deprecations?: readonly FieldDeprecation[];
+	};
 }
 
-const PREFIX = "__ENVELOPE_V1__:";
+/**
+ * Build the envelope `meta` block from a single source of truth. Stamps the
+ * current `version` and attaches `deprecations` only when the registry is
+ * non-empty (keeps the wire format clean while nothing is deprecated).
+ *
+ * `deprecations` defaults to the global `ENVELOPE_DEPRECATIONS` registry;
+ * production callers pass only `tool` (and optionally `ts`). The parameter is
+ * exposed so the surfacing behaviour can be unit-tested without mutating the
+ * global registry.
+ */
+export function buildEnvelopeMeta(
+	tool: string,
+	ts: string = new Date().toISOString(),
+	deprecations: readonly FieldDeprecation[] = ENVELOPE_DEPRECATIONS,
+): ToolEnvelope["meta"] {
+	const meta: ToolEnvelope["meta"] = { tool, ts, version: ENVELOPE_VERSION };
+	if (deprecations.length > 0) {
+		meta.deprecations = deprecations;
+	}
+	return meta;
+}
 
 export function toToolResult<T>(env: ToolEnvelope<T>): TextToolResult {
 	const encoded = Buffer.from(
@@ -16,14 +88,34 @@ export function toToolResult<T>(env: ToolEnvelope<T>): TextToolResult {
 	return {
 		content: [
 			{ type: "text", text: env.summaryMarkdown },
-			{ type: "text", text: `${PREFIX}${encoded}` },
+			{ type: "text", text: `${ENVELOPE_PREFIX}${encoded}` },
 		],
 	};
 }
 
+/** Matches any envelope text-block prefix, capturing the integer version. */
+const ENVELOPE_PREFIX_PATTERN = /^__ENVELOPE_V(\d+)__:/;
+
+/**
+ * Parse an envelope text block. Version-aware and forward-compatible:
+ * - Rejects a block whose version this consumer does not support with an
+ *   explicit error, rather than silently mis-parsing or reporting "not an
+ *   envelope".
+ * - Preserves unknown payload/meta fields (additive changes never break an
+ *   older parser).
+ */
 export function parseEnvelopeBlock<T = unknown>(text: string): ToolEnvelope<T> {
-	if (!text.startsWith(PREFIX)) throw new Error("not an envelope block");
-	const json = Buffer.from(text.slice(PREFIX.length), "base64").toString(
+	const match = ENVELOPE_PREFIX_PATTERN.exec(text);
+	if (!match) throw new Error("not an envelope block");
+	const version = Number(match[1]);
+	if (!SUPPORTED_ENVELOPE_VERSIONS.includes(version)) {
+		throw new Error(
+			`unsupported envelope version ${version} (this consumer supports v${SUPPORTED_ENVELOPE_VERSIONS.join(", v")})`,
+		);
+	}
+	// Slice by the actually-matched prefix, not a rebuilt one, so a non-canonical
+	// version token (e.g. a zero-padded `V01`) can't desync the base64 offset.
+	const json = Buffer.from(text.slice(match[0].length), "base64").toString(
 		"utf8",
 	);
 	const parsed = JSON.parse(json) as { payload: T; meta: ToolEnvelope["meta"] };

--- a/src/tools/tool-call-handler.ts
+++ b/src/tools/tool-call-handler.ts
@@ -41,7 +41,7 @@ import {
 	formatWorkflowResult,
 } from "./result-formatter.js";
 import { buildMcpErrorContent } from "./shared/error-handler.js";
-import { toToolResult } from "./shared/output-envelope.js";
+import { buildEnvelopeMeta, toToolResult } from "./shared/output-envelope.js";
 import {
 	dispatchWorkspaceToolCall,
 	resolveWorkspaceToolName,
@@ -317,11 +317,7 @@ export async function dispatchToolCall(
 				// instructionId is required by the tool-coverage-matrix test which checks
 				// that every workflow tool envelope carries instructionId === toolName.
 				payload: { ...result.payload, instructionId: "analogy-think" },
-				meta: {
-					tool: "analogy-think",
-					ts: new Date().toISOString(),
-					version: 1,
-				},
+				meta: buildEnvelopeMeta("analogy-think"),
 			});
 		}
 
@@ -518,22 +514,14 @@ export async function dispatchToolCall(
 			return toToolResult({
 				summaryMarkdown: summaryWithGate,
 				payload: payloadWithGate,
-				meta: {
-					tool: toolName,
-					ts: new Date().toISOString(),
-					version: 1,
-				},
+				meta: buildEnvelopeMeta(toolName),
 			});
 		}
 
 		return toToolResult({
 			summaryMarkdown: rawSummary,
 			payload: rawPayload,
-			meta: {
-				tool: toolName,
-				ts: new Date().toISOString(),
-				version: 1,
-			},
+			meta: buildEnvelopeMeta(toolName),
 		});
 	} catch (error) {
 		// Detect unknown-instruction / unknown-tool-name errors: these signal that


### PR DESCRIPTION
## 📝 Summary

Two follow-ups from ADR 0001 (sampler round-trip removal), which dropped the `situationMode` envelope field with no version-bump or deprecation signal.

- **#1603** — establishes a forward-looking envelope schema **versioning + deprecation policy** so future field removals aren't silent.
- **#1602** — proves the ADR's "workspace grounding serves headless/eval/non-LLM consumers" claim with a **real non-LLM consumer** citing real file paths, no model in the loop.

Non-breaking: the v1 wire format is unchanged (`__ENVELOPE_V1__:` prefix, same `meta` fields; `deprecations` is optional and only stamped when the registry is non-empty, which it isn't yet).

### 🔗 Related Issues

Closes #1603
Closes #1602

## 📦 Key Changes

**#1603 — `src/tools/shared/output-envelope.ts`**
1. Single-source the version: `ENVELOPE_VERSION`, derived `ENVELOPE_PREFIX`, `SUPPORTED_ENVELOPE_VERSIONS`.
2. Machine-readable deprecation registry (`FieldDeprecation` + `ENVELOPE_DEPRECATIONS`, starts empty) surfaced via `meta.deprecations` by a new `buildEnvelopeMeta()` helper — the capability flag consumers key off *before* a field is removed.
3. `parseEnvelopeBlock` is version-aware: rejects unknown/future versions with an explicit error (no silent misparse), slices by the matched prefix (robust to non-canonical version tokens), preserves unknown fields (forward-compat).
4. Migrated the 4 producer sites (`error-handler.ts`, 3× `tool-call-handler.ts`) off inlined `version: 1` literals.
5. Policy documented in `docs/adr/0002-envelope-schema-versioning-policy.md`.

**#1602 — headless grounding consumer**
1. `src/tests/evals/workspace-grounding-consumer.test.ts` — drives the **real** `createWorkspaceSurface()` over a temp file (no mock reader, no sampler, no LLM) and asserts workspace-grounded findings cite a path that resolves on disk.
2. `evals/workspace-grounding-consumer.mjs` — runnable non-LLM harness that gates on grounded findings citing real files and writes `evals/workspace-grounding-results.json`; documented in `evals/workspace-grounding.md`.

#### Modified Components
- 🔧 Shared utilities (`src/tools/shared/`)
- 🛠️ Core tools (`src/tools/`)
- 🧪 Tests (`src/tests/`)
- 📚 Documentation (`docs/adr/`, `evals/`)

## 🧪 Testing

- `npx vitest run src/tests/tools/shared/output-envelope.test.ts` — versioning, deprecation surfacing + round-trip, future-version rejection, forward-compat, registry invariant.
- `npx vitest run src/tests/evals/workspace-grounding-consumer.test.ts` — real-filesystem grounded findings cite on-disk paths.
- `node evals/workspace-grounding-consumer.mjs` — exits 0, one grounded finding citing `src/payments/charge.ts`.
- Envelope-consumer regression set (`error-handler`, `result-formatter`, `tool-coverage-matrix`, `cross-blind-*`) green.
- **Full suite: 271 files, 2602 tests passed, 3 skipped.** `npm run check` (biome) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)