### PR TITLE
feat(prompt): adopt universal-creator technique catalog + selector; Serena symbol grounding; auto-mode audit (#1605 #1601 #1445)

### DIFF
--- a/docs/src/content/docs/skills/prompting.md
+++ b/docs/src/content/docs/skills/prompting.md
@@ -105,15 +105,16 @@ These techniques are documented here for completeness but are **not** in the cat
 
 | ID | Name | Prerequisite |
 |----|------|--------------|
-| `ape` / `active-prompt` | Automatic Prompt Engineer | Requires a prompt/example pool + evaluator pipeline |
+| `ape` | Automatic Prompt Engineer | Requires a prompt/example pool + evaluator to score candidate prompts at classify time |
+| `active-prompt` | Active-Prompt | Requires an example pool + uncertainty-based selection (no pool available at classify time) |
 | `multimodal-cot` | Multimodal Chain-of-Thought | Requires image input in `baseSkillInputSchema` |
 | `graph-prompting` | Graph Prompting | Requires knowledge-graph / triple-store input |
-| `dsp` | Decomposed Structured Prompting | Requires RAG composition layer (≈ decompose + RAG) |
-| `art` | Automatic Reasoning and Tool-use | Functionally overlaps ReAct; deferred until differentiation is clear |
+| `dsp` | Decomposed Structured Prompting | Requires RAG composition (decompose from orch-* skills + retrieve from RAG) |
+| `art` | Automatic Reasoning and Tool-use | Functionally overlaps ReAct; deferred until a differentiating trigger exists |
 
 ### Deterministic Selector
 
-The selector (`src/skills/prompt/technique-selector.ts`) is **fully deterministic** — it uses keyword and signal scoring, consistent with [ADR 0001: Remove Sampler Round-Trip](../../../../docs/adr/0001-remove-sampler-round-trip.md). There is no LLM sampler involved.
+The selector (`src/skills/prompt/technique-selector.ts`) is **fully deterministic** — it uses keyword and signal scoring, consistent with [ADR 0001: Remove Sampler Round-Trip](../../../../adr/0001-remove-sampler-round-trip.md). There is no LLM sampler involved.
 
 Selection algorithm:
 

--- a/docs/src/content/docs/skills/prompting.md
+++ b/docs/src/content/docs/skills/prompting.md
@@ -62,3 +62,109 @@ Modified prompt → eval-prompt re-score
       ↓
 Repeat until score ≥ threshold
 ```
+
+---
+
+## Technique Catalog
+
+`prompt-engineering` ships an internal technique catalog with a **deterministic selector** (`src/skills/prompt/technique-catalog.ts` + `technique-selector.ts`). These are internal modules consumed by the skill — they are **not** registered as public MCP tools and therefore do **not** appear in `src/generated/graph/**`.
+
+The catalog is ported under MIT from [Anselmoo/universal-creator](https://github.com/Anselmoo/universal-creator)'s `skills/shared/techniques.json`.
+
+### 12 Techniques in 3 Tiers
+
+#### Tier 1 — First-Class (7, with worked cards)
+
+These techniques have a full worked-example card in `technique-examples.ts` and are the primary selection targets of the deterministic selector.
+
+| ID | Name | Category | Escalates To |
+|----|------|----------|--------------|
+| `react` | ReAct (Reason + Act) | `agentic` | `rag`, `reflexion` |
+| `rag` | Retrieval-Augmented Generation | `retrieval` | `reflexion` |
+| `reflexion` | Reflexion | `self-improvement` | `meta-prompting` |
+| `tree-of-thoughts` | Tree of Thoughts | `reasoning` | `self-consistency` |
+| `pal` | Program-Aided Language Models | `reasoning` | `self-consistency` |
+| `self-consistency` | Self-Consistency | `reasoning` | `tree-of-thoughts` |
+| `meta-prompting` | Meta-Prompting | `self-improvement` | `reflexion` |
+
+#### Tier 2 — Catalog-Only (5, no worked cards)
+
+These techniques are present in the catalog for keyword scoring and escalation routing, but do not have worked-example cards.
+
+| ID | Name | Category | Escalates To |
+|----|------|----------|--------------|
+| `zero-shot` | Zero-Shot Prompting | `baseline` | `few-shot` |
+| `few-shot` | Few-Shot Prompting | `baseline` | `cot`, `reflexion` |
+| `cot` | Chain-of-Thought | `reasoning` | `pal`, `self-consistency`, `tree-of-thoughts` |
+| `prompt-chaining` | Prompt Chaining | `baseline` | `react` |
+| `generate-knowledge` | Generate Knowledge | `retrieval` | `rag` |
+
+#### Tier 3 — Deferred (6, not implemented)
+
+These techniques are documented here for completeness but are **not** in the catalog. Each has a specific infrastructure prerequisite that must be met before implementation.
+
+| ID | Name | Prerequisite |
+|----|------|--------------|
+| `ape` / `active-prompt` | Automatic Prompt Engineer | Requires a prompt/example pool + evaluator pipeline |
+| `multimodal-cot` | Multimodal Chain-of-Thought | Requires image input in `baseSkillInputSchema` |
+| `graph-prompting` | Graph Prompting | Requires knowledge-graph / triple-store input |
+| `dsp` | Decomposed Structured Prompting | Requires RAG composition layer (≈ decompose + RAG) |
+| `art` | Automatic Reasoning and Tool-use | Functionally overlaps ReAct; deferred until differentiation is clear |
+
+### Deterministic Selector
+
+The selector (`src/skills/prompt/technique-selector.ts`) is **fully deterministic** — it uses keyword and signal scoring, consistent with [ADR 0001: Remove Sampler Round-Trip](../../../../docs/adr/0001-remove-sampler-round-trip.md). There is no LLM sampler involved.
+
+Selection algorithm:
+
+```
+1. Extract signals from InstructionInput (request + context)
+2. Score every catalog entry by keyword match count
+3. Pick the highest-scoring entry as primary
+4. Add up to 2 supplementary techniques from the same category
+5. Attach structural requirements from primary.structureSignals
+6. Build rationale string (category + score + escalation edges)
+7. Set confident: false if score == 0 → unclassified
+```
+
+#### Selection Output
+
+```ts
+interface TechniqueSelection {
+  category: TechniqueCategory | "unclassified";
+  primary: string | null;          // technique id
+  supplementary: string[];         // up to 2 same-category ids
+  structureRequirements: string[]; // from primary.structureSignals
+  rationale: string;               // human-readable explanation
+  confident: boolean;
+  exampleRef: string | null;       // worked card id, null for catalog-only
+}
+```
+
+### Escalation Model
+
+Each catalog entry carries `escalatesTo` edges pointing to higher-capability techniques within the same or an adjacent category. The selector surfaces these edges in the `rationale` field — they are suggestions, not automatic transitions.
+
+```
+zero-shot → few-shot → cot → pal / self-consistency / tree-of-thoughts
+                            ↘ reflexion
+generate-knowledge → rag → reflexion → meta-prompting
+prompt-chaining → react → rag / reflexion
+```
+
+**Graph boundary:** escalation edges live in catalog data and selector rationale only. Because these techniques are internal skill modules (not registered MCP tools), they do **not** appear in `src/generated/graph/instruction-skill-edges.ts` or any other generated graph file. The public tool graph reflects only registered instructions and skills.
+
+### Structural Requirements
+
+Each first-class technique specifies 3–5 structural requirements (`structureSignals`) that constrain prompt shape. For example, `react` requires:
+
+- Interleave Thought → Action → Observation steps explicitly.
+- Name the tool/action namespace the model may call.
+- Require the model to stop and observe before the next action.
+- Define a termination condition (answer found or budget exhausted).
+
+The selector passes these requirements directly to the skill as `structureRequirements` so the prompt author receives concrete constraints, not just a technique name.
+
+### Attribution
+
+The catalog data (technique definitions, keywords, structural signals, escalation edges, and worked-example cards) is ported under the **MIT License** from [Anselmoo/universal-creator](https://github.com/Anselmoo/universal-creator). See `src/skills/prompt/technique-catalog.ts` and `src/skills/prompt/technique-examples.ts` for the source headers.

--- a/docs/superpowers/plans/2026-07-05-technique-catalog-grounding-automode.md
+++ b/docs/superpowers/plans/2026-07-05-technique-catalog-grounding-automode.md
@@ -1,0 +1,686 @@
+# Technique Catalog + Serena Grounding + Auto-Mode Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt universal-creator's prompt-technique catalog + a deterministic selector into the `prompt-engineering` pipeline (Issue 1605 Phases 1–5), thread Serena symbol grounding into skill execution (Issue 1601), and verify/harden the already-shipped auto-mode surface (Issue 1445).
+
+**Architecture:** A typed, data-only technique catalog (`technique-catalog.ts`) + a pure deterministic selector (`technique-selector.ts`) reusing the existing `extractRequestSignals` + `rankCandidateTools` primitives — no sampler, no new public tools. The selector's output is folded into `prompt-engineering`'s recommendation/artifact set. Serena grounding is added as a bounded, never-throws helper alongside the existing file-grounding helper. 1445 is locked with regression tests + a description-field audit.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), Zod, Vitest, Biome; Python codegen (`generate-tool-definitions.py`); MCP servers: `serena`, `mcp-server-analyzer`, local `ai-agent-guidelines`.
+
+## Global Constraints
+
+- **No sampler round-trip.** Selector must be pure/deterministic (keyword + signal scoring only). Ref `docs/adr/0001-remove-sampler-round-trip.md`.
+- **Never hand-edit `src/generated/**`.** Edit sources (`src/instructions/instruction-specs.ts`, skill sources), then run `python3 scripts/generate-tool-definitions.py` + `npm run generate:skill-docs`.
+- **No tool-surface explosion.** Enrich the 4 existing prompt skills only. No per-technique public MCP tools.
+- **Attribution.** Port under MIT with credit to `Anselmoo/universal-creator` in catalog module header + docs.
+- **ESM imports** use `.js` specifiers even for `.ts` files (repo convention).
+- **Determinism:** same input → identical output (no `Date.now`, no `Math.random`, stable sort).
+- **Gates green before done:** `npm test`, `python3 scripts/verify_matrix.py`, `npm run quality`, `npm run check:generated`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Stage |
+|---|---|---|
+| `src/skills/prompt/technique-catalog.ts` (new) | Typed data catalog: 12 technique entries + accessor helpers | A/C/D |
+| `src/skills/prompt/technique-selector.ts` (new) | Pure classifier: request → category + primary/supplementary + rationale | A |
+| `src/skills/prompt/technique-examples.ts` (new) | Worked-card data for the 7 first-class techniques | B |
+| `src/skills/prompt/prompt-engineering.ts` (modify) | Call selector in STRUCTURE step; emit selection recommendation + matrix artifact | A/B |
+| `src/skills/shared/workspace-grounding.ts` (modify) | Add `resolveSymbolGrounding()` (Serena, bounded) | F |
+| `src/skills/runtime/*` skill-registry (modify) | Thread `serena` into `SkillExecutionRuntime` | F |
+| `src/contracts/runtime.ts` (modify) | Add `serena?` to `SkillExecutionRuntime`; new artifact kind only if needed | B/F |
+| `src/instructions/instruction-specs.ts` (modify) | Description-field audit (item 5) | G |
+| `src/tests/skills/prompt/technique-catalog.test.ts` (new) | Catalog well-formedness + escalation integrity | A |
+| `src/tests/skills/prompt/technique-selector.test.ts` (new) | Refutable trigger per technique | A |
+| `src/tests/skills/shared/workspace-grounding.test.ts` (modify) | Serena grounding + graceful degradation | F |
+| `src/tests/tools/tool-surface-manifest.test.ts` (new/modify) | Lock 1445 invariants | G |
+| `docs/src/content/docs/skills/prompting.md` (modify) | Document catalog/selector/escalation + attribution | E |
+
+**Category vocabulary (fixed, 5 values):** `reasoning | retrieval | agentic | self-improvement | baseline`.
+
+**Technique data (all 12 — no TBD):**
+
+| id | tier | category | keywords (for rank) | escalatesTo |
+|---|---|---|---|---|
+| `zero-shot` | catalog-only | baseline | direct, simple, single, quick, straightforward | few-shot |
+| `few-shot` | catalog-only | baseline | example, examples, few-shot, demonstrate, sample | cot, reflexion |
+| `cot` | catalog-only | reasoning | reason, step by step, think, explain, logic | pal, self-consistency, tree-of-thoughts |
+| `self-consistency` | first-class | reasoning | consistent, vote, majority, sample, reliability | tree-of-thoughts |
+| `tree-of-thoughts` | first-class | reasoning | explore, branch, alternative, backtrack, search, options | self-consistency |
+| `pal` | first-class | reasoning | calculate, compute, math, code, program, arithmetic, numeric | self-consistency |
+| `rag` | first-class | retrieval | retrieve, document, knowledge base, source, citation, ground | reflexion |
+| `generate-knowledge` | catalog-only | retrieval | background, facts, recall, elaborate, knowledge | rag |
+| `react` | first-class | agentic | tool, agent, action, observe, api, call, interact | rag, reflexion |
+| `reflexion` | first-class | self-improvement | reflect, self-critique, improve, iterate, feedback, retry | meta-prompting |
+| `meta-prompting` | first-class | self-improvement | meta, critique the prompt, regenerate, refine prompt | reflexion |
+| `prompt-chaining` | catalog-only | baseline | chain, multi-step, pipeline, sequence, stage, decompose | react |
+
+---
+
+## Stage 0 — Baseline (already partially done: build is green)
+
+### Task 0: Characterization baseline
+
+**Files:**
+- Create: `src/tests/skills/prompt/prompt-engineering-baseline.test.ts`
+
+**Interfaces:**
+- Consumes: `skillModule` from `src/skills/prompt/prompt-engineering.js`; `expectSkillGuidance` from `../test-helpers.js`.
+- Produces: a snapshot the Stage A diff is measured against.
+
+- [ ] **Step 1: Write a characterization test** capturing today's artifact-kind order (from the existing test): `["comparison-matrix","output-template","worked-example","tool-chain"]` for a request without success criteria, plus `"eval-criteria"` when `successCriteria` is set.
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { skillModule } from "../../../skills/prompt/prompt-engineering.js";
+import { createMockSkillRuntime } from "../test-helpers.js";
+
+describe("prompt-engineering baseline (pre-selector)", () => {
+	it("emits the current artifact-kind order for a plain request", async () => {
+		const result = await skillModule.run(
+			{ request: "Write a summarization prompt" },
+			createMockSkillRuntime(),
+		);
+		expect(result.artifacts?.map((a) => a.kind)).toEqual([
+			"comparison-matrix",
+			"output-template",
+			"worked-example",
+			"tool-chain",
+		]);
+	});
+});
+```
+
+- [ ] **Step 2: Run it — expect PASS.** `npx vitest run src/tests/skills/prompt/prompt-engineering-baseline.test.ts`
+- [ ] **Step 3: Dogfood the local MCP** (build already green). Confirm `dist/index.js` exists: `ls dist/index.js`. This unblocks the `ai-agent-guidelines` server in `.mcp.json` for later manual verification.
+- [ ] **Step 4: Commit.** `git add -A && git commit -m "test: characterization baseline for prompt-engineering artifacts"`
+
+---
+
+## Stage A — Technique catalog + deterministic selector (1605 Phase 1)
+
+### Task 1: Technique catalog module + type
+
+**Files:**
+- Create: `src/skills/prompt/technique-catalog.ts`
+- Test: `src/tests/skills/prompt/technique-catalog.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type TechniqueCategory = "reasoning" | "retrieval" | "agentic" | "self-improvement" | "baseline";`
+  - `type TechniqueTier = "first-class" | "catalog-only";`
+  - `interface TechniqueEntry { id: string; name: string; category: TechniqueCategory; tier: TechniqueTier; keywords: readonly string[]; structureSignals: readonly string[]; useCase: string; escalatesTo: readonly string[]; exampleRef?: string; }`
+  - `const TECHNIQUE_CATALOG: readonly TechniqueEntry[]`
+  - `function getTechnique(id: string): TechniqueEntry | undefined`
+  - `function techniquesByCategory(cat: TechniqueCategory): readonly TechniqueEntry[]`
+
+- [ ] **Step 1: Write the failing test** `technique-catalog.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import {
+	TECHNIQUE_CATALOG,
+	getTechnique,
+} from "../../../skills/prompt/technique-catalog.js";
+
+describe("technique-catalog", () => {
+	it("holds exactly the 12 non-deferred techniques", () => {
+		expect(TECHNIQUE_CATALOG).toHaveLength(12);
+		expect(new Set(TECHNIQUE_CATALOG.map((t) => t.id)).size).toBe(12);
+	});
+
+	it("gives every entry ≥1 keyword and 3–5 structure signals", () => {
+		for (const t of TECHNIQUE_CATALOG) {
+			expect(t.keywords.length).toBeGreaterThan(0);
+			expect(t.structureSignals.length).toBeGreaterThanOrEqual(3);
+			expect(t.structureSignals.length).toBeLessThanOrEqual(5);
+		}
+	});
+
+	it("only escalates to real technique ids (no dangling edges)", () => {
+		for (const t of TECHNIQUE_CATALOG) {
+			for (const target of t.escalatesTo) {
+				expect(getTechnique(target), `${t.id}→${target}`).toBeDefined();
+			}
+		}
+	});
+
+	it("marks exactly the 7 first-class techniques", () => {
+		const firstClass = TECHNIQUE_CATALOG.filter(
+			(t) => t.tier === "first-class",
+		).map((t) => t.id);
+		expect(firstClass.sort()).toEqual(
+			[
+				"meta-prompting",
+				"pal",
+				"rag",
+				"react",
+				"reflexion",
+				"self-consistency",
+				"tree-of-thoughts",
+			].sort(),
+		);
+	});
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** ("Cannot find module technique-catalog"). `npx vitest run src/tests/skills/prompt/technique-catalog.test.ts`
+- [ ] **Step 3: Implement `technique-catalog.ts`.** Header credits universal-creator (MIT). Encode all 12 entries per the data table above. Pattern (showing 3 representative entries — fill the rest from the table with equally specific `useCase`/`structureSignals`):
+
+```typescript
+/**
+ * Prompt-technique catalog — ported (MIT) from Anselmoo/universal-creator's
+ * skills/shared/techniques.json. Data-only: the deterministic selector
+ * (technique-selector.ts) ranks these; no sampler, no per-technique tools.
+ */
+
+export type TechniqueCategory =
+	| "reasoning"
+	| "retrieval"
+	| "agentic"
+	| "self-improvement"
+	| "baseline";
+
+export type TechniqueTier = "first-class" | "catalog-only";
+
+export interface TechniqueEntry {
+	id: string;
+	name: string;
+	category: TechniqueCategory;
+	tier: TechniqueTier;
+	/** Keywords for deterministic ranking (mirrors ROUTING_KEYWORDS pattern). */
+	keywords: readonly string[];
+	/** 3–5 structural requirements the technique imposes on the prompt. */
+	structureSignals: readonly string[];
+	useCase: string;
+	/** technique→technique escalation edges (Stage D). */
+	escalatesTo: readonly string[];
+	/** Pointer to a worked card in technique-examples.ts (first-class only). */
+	exampleRef?: string;
+}
+
+export const TECHNIQUE_CATALOG: readonly TechniqueEntry[] = [
+	{
+		id: "react",
+		name: "ReAct (Reason + Act)",
+		category: "agentic",
+		tier: "first-class",
+		keywords: ["tool", "agent", "action", "observe", "api", "call", "interact"],
+		structureSignals: [
+			"Interleave Thought → Action → Observation steps explicitly.",
+			"Name the tool/action namespace the model may call.",
+			"Require the model to stop and observe before the next action.",
+			"Define a termination condition (answer found or budget exhausted).",
+		],
+		useCase:
+			"Tasks needing external tool calls with observation between steps.",
+		escalatesTo: ["rag", "reflexion"],
+		exampleRef: "react",
+	},
+	{
+		id: "cot",
+		name: "Chain-of-Thought",
+		category: "reasoning",
+		tier: "catalog-only",
+		keywords: ["reason", "step by step", "think", "explain", "logic"],
+		structureSignals: [
+			"Ask for explicit intermediate reasoning before the answer.",
+			"Separate the reasoning trace from the final answer field.",
+			"Keep each reasoning step to one inference.",
+		],
+		useCase: "Multi-step reasoning where showing the work improves accuracy.",
+		escalatesTo: ["pal", "self-consistency", "tree-of-thoughts"],
+	},
+	{
+		id: "rag",
+		name: "Retrieval-Augmented Generation",
+		category: "retrieval",
+		tier: "first-class",
+		keywords: [
+			"retrieve",
+			"document",
+			"knowledge base",
+			"source",
+			"citation",
+			"ground",
+		],
+		structureSignals: [
+			"Specify retrieval order: system rules → task → retrieved evidence.",
+			"Require answers to cite the retrieved source ids.",
+			"Define behavior when retrieval returns nothing relevant.",
+			"Bound context window usage for retrieved chunks.",
+		],
+		useCase: "Answers must be grounded in an external corpus with citations.",
+		escalatesTo: ["reflexion"],
+		exampleRef: "rag",
+	},
+	// … remaining 9 entries: self-consistency, tree-of-thoughts, pal,
+	// generate-knowledge, reflexion, meta-prompting, zero-shot, few-shot,
+	// prompt-chaining — each populated from the data table with a specific
+	// useCase and 3–5 structureSignals.
+];
+
+const BY_ID = new Map(TECHNIQUE_CATALOG.map((t) => [t.id, t]));
+
+export function getTechnique(id: string): TechniqueEntry | undefined {
+	return BY_ID.get(id);
+}
+
+export function techniquesByCategory(
+	cat: TechniqueCategory,
+): readonly TechniqueEntry[] {
+	return TECHNIQUE_CATALOG.filter((t) => t.category === cat);
+}
+```
+
+- [ ] **Step 4: Run — expect PASS.** `npx vitest run src/tests/skills/prompt/technique-catalog.test.ts`
+- [ ] **Step 5: Lint + commit.** `mcp-server-analyzer biome-check` on the two files, then `git add -A && git commit -m "feat(prompt): add ported technique catalog (12 entries, MIT)"`
+
+### Task 2: Deterministic selector
+
+**Files:**
+- Create: `src/skills/prompt/technique-selector.ts`
+- Test: `src/tests/skills/prompt/technique-selector.test.ts`
+
+**Interfaces:**
+- Consumes: `extractRequestSignals` (`../shared/recommendations.js`), `rankCandidateTools` (`../shared/directive-first.js`), `TECHNIQUE_CATALOG`/`getTechnique` (`./technique-catalog.js`), `InstructionInput`.
+- Produces:
+  - `interface TechniqueSelection { category: TechniqueCategory | "unclassified"; primary: string | null; supplementary: string[]; structureRequirements: string[]; rationale: string; confident: boolean; }`
+  - `function selectTechniques(input: InstructionInput): TechniqueSelection`
+
+**Design note:** `rankCandidateTools` reads its own module-level `ROUTING_KEYWORDS` map — it will NOT see technique keywords. So the selector implements its own small scorer over `TECHNIQUE_CATALOG[].keywords` (same stable-sort algorithm), and uses `extractRequestSignals` for the empty/low-signal gate. This keeps determinism and reuses the *pattern* without polluting the router's keyword map.
+
+- [ ] **Step 1: Write the failing test** — a refutable trigger per technique (positive selects it; a contrasting input does not):
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { selectTechniques } from "../../../skills/prompt/technique-selector.js";
+
+const sel = (request: string) => selectTechniques({ request });
+
+describe("technique-selector (refutable triggers)", () => {
+	it("selects react for tool-observation agent tasks, not for plain summaries", () => {
+		expect(sel("an agent that calls an API tool then observes the result").primary).toBe("react");
+		expect(sel("write a short summary of this paragraph").primary).not.toBe("react");
+	});
+
+	it("selects rag for retrieval/citation tasks, not for pure arithmetic", () => {
+		expect(sel("answer from the knowledge base and cite the source document").primary).toBe("rag");
+		expect(sel("compute the factorial of 12").primary).not.toBe("rag");
+	});
+
+	it("selects pal for compute/math tasks, not for tone rewriting", () => {
+		expect(sel("calculate and compute the numeric result with code").primary).toBe("pal");
+		expect(sel("make this email sound friendlier").primary).not.toBe("pal");
+	});
+
+	it("selects self-consistency when reliability via voting is asked", () => {
+		expect(sel("sample multiple answers and take the majority vote for reliability").primary).toBe("self-consistency");
+	});
+
+	it("selects tree-of-thoughts for branch/backtrack exploration", () => {
+		expect(sel("explore alternative branches and backtrack to search options").primary).toBe("tree-of-thoughts");
+	});
+
+	it("selects reflexion for self-critique/iterate loops", () => {
+		expect(sel("reflect on the failure, self-critique, and iterate with feedback").primary).toBe("reflexion");
+	});
+
+	it("selects meta-prompting for regenerating the prompt itself", () => {
+		expect(sel("critique the prompt and regenerate a refined prompt").primary).toBe("meta-prompting");
+	});
+
+	it("emits ≤2 supplementary techniques and a rationale string", () => {
+		const r = sel("an agent that calls a tool then observes and cites a document");
+		expect(r.supplementary.length).toBeLessThanOrEqual(2);
+		expect(r.rationale.length).toBeGreaterThan(0);
+	});
+
+	it("is low-confidence + unclassified when no technique keyword matches", () => {
+		const r = sel("hello");
+		expect(r.confident).toBe(false);
+		expect(r.primary).toBeNull();
+	});
+
+	it("is deterministic (same input → same output)", () => {
+		const a = sel("an agent that calls a tool then observes");
+		const b = sel("an agent that calls a tool then observes");
+		expect(a).toEqual(b);
+	});
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL.** `npx vitest run src/tests/skills/prompt/technique-selector.test.ts`
+- [ ] **Step 3: Implement `technique-selector.ts`:**
+
+```typescript
+import type { InstructionInput } from "../../contracts/runtime.js";
+import { extractRequestSignals } from "../shared/recommendations.js";
+import {
+	TECHNIQUE_CATALOG,
+	type TechniqueCategory,
+	type TechniqueEntry,
+	getTechnique,
+} from "./technique-catalog.js";
+
+export interface TechniqueSelection {
+	category: TechniqueCategory | "unclassified";
+	primary: string | null;
+	supplementary: string[];
+	structureRequirements: string[];
+	rationale: string;
+	confident: boolean;
+}
+
+/** Stable keyword scorer over the catalog (mirrors rankCandidateTools). */
+function scoreTechniques(
+	request: string,
+): { entry: TechniqueEntry; score: number }[] {
+	const lower = request.toLowerCase();
+	return TECHNIQUE_CATALOG.map((entry, index) => ({
+		entry,
+		index,
+		score: entry.keywords.filter((kw) => lower.includes(kw)).length,
+	}))
+		.sort((a, b) => b.score - a.score || a.index - b.index)
+		.map(({ entry, score }) => ({ entry, score }));
+}
+
+export function selectTechniques(input: InstructionInput): TechniqueSelection {
+	const signals = extractRequestSignals(input);
+	const combined = `${input.request ?? ""} ${input.context ?? ""}`;
+	const ranked = scoreTechniques(combined);
+	const top = ranked[0];
+
+	if (!top || top.score === 0 || signals.keywords.length === 0) {
+		return {
+			category: "unclassified",
+			primary: null,
+			supplementary: [],
+			structureRequirements: [],
+			rationale:
+				"No technique keyword matched the request; defaulting to unclassified. Provide the task's reasoning/retrieval/tool-use shape to select a technique.",
+			confident: false,
+		};
+	}
+
+	const primary = top.entry;
+	const supplementary = ranked
+		.slice(1)
+		.filter((r) => r.score > 0 && r.entry.category === primary.category)
+		.slice(0, 2)
+		.map((r) => r.entry.id);
+
+	const escalation = primary.escalatesTo
+		.map((id) => getTechnique(id)?.name)
+		.filter((n): n is string => Boolean(n));
+
+	const rationale = [
+		`Classified as ${primary.category}: strongest keyword match is ${primary.name} (${top.score} signal${top.score === 1 ? "" : "s"}).`,
+		supplementary.length
+			? `Supplementary: ${supplementary.join(", ")}.`
+			: "",
+		escalation.length
+			? `Consider escalating to ${escalation.join(" or ")} if the primary technique underperforms.`
+			: "",
+	]
+		.filter(Boolean)
+		.join(" ");
+
+	return {
+		category: primary.category,
+		primary: primary.id,
+		supplementary,
+		structureRequirements: [...primary.structureSignals],
+		rationale,
+		confident: true,
+	};
+}
+```
+
+- [ ] **Step 4: Run — expect PASS.** `npx vitest run src/tests/skills/prompt/technique-selector.test.ts`
+- [ ] **Step 5: Commit.** `git add -A && git commit -m "feat(prompt): deterministic technique selector (refutable triggers)"`
+
+### Task 3: Wire selector into prompt-engineering STRUCTURE step
+
+**Files:**
+- Modify: `src/skills/prompt/prompt-engineering.ts`
+- Modify: `src/tests/skills/prompt/prompt-engineering.test.ts`
+
+**Interfaces:**
+- Consumes: `selectTechniques` from `./technique-selector.js`.
+- Produces: an added recommendation detail naming the selected technique + a new `comparison-matrix` artifact `"Technique selection"`.
+
+- [ ] **Step 1: Extend the existing test** — assert the selected technique surfaces. Add to the guidance test (request already mentions few-shot/system): expect a detail fragment naming a technique and the rationale.
+
+```typescript
+	it("names a selected technique for a tool-use request", async () => {
+		const result = await expectSkillGuidance(
+			skillModule,
+			{ request: "prompt for an agent that calls a tool then observes the result" },
+			{ detailIncludes: ["Selected technique"] },
+		);
+		expect(
+			result.artifacts?.some((a) => a.kind === "comparison-matrix" && a.title === "Technique selection"),
+		).toBe(true);
+	});
+```
+
+- [ ] **Step 2: Run — expect FAIL.** `npx vitest run src/tests/skills/prompt/prompt-engineering.test.ts`
+- [ ] **Step 3: Implement the wire-in.** Import the selector; after the existing `details` are built (around line 145, before the `artifacts` array), insert:
+
+```typescript
+	const selection = selectTechniques(parsed.data);
+	if (selection.confident && selection.primary) {
+		details.push(
+			`Selected technique: ${selection.primary} (${selection.category}). ${selection.rationale} Structural requirements: ${selection.structureRequirements.join(" ")}`,
+		);
+	}
+```
+
+Then append a matrix artifact to the `artifacts` array (keep it AFTER the existing four so the baseline order is preserved as a prefix):
+
+```typescript
+	if (selection.confident && selection.primary) {
+		artifacts.push(
+			buildComparisonMatrixArtifact(
+				"Technique selection",
+				["Role", "Technique", "Why"],
+				[
+					{ label: "primary", values: [selection.primary, selection.category] },
+					...selection.supplementary.map((id) => ({
+						label: "supplementary",
+						values: [id, "same-category support"],
+					})),
+				],
+				selection.rationale,
+			),
+		);
+	}
+```
+
+- [ ] **Step 4: Update the baseline/existing artifact-order test.** The existing assertion `toEqual([...])` now has a trailing `"comparison-matrix"` for confident selections. The `system prompt` request in that test WILL classify (mentions "few-shot"/"safety"), so update its expected array to append `"comparison-matrix"`. Re-verify Stage 0's plain-request test still holds (a plain "Write a summarization prompt" scores 0 → no extra artifact).
+- [ ] **Step 5: Run — expect PASS.** `npx vitest run src/tests/skills/prompt/`
+- [ ] **Step 6: Dogfood via local MCP.** Rebuild (`npm run build`), then call the local `ai-agent-guidelines` `prompt-engineering` tool with a ReAct request; confirm the output names `react`. Compare to the Stage 0 snapshot.
+- [ ] **Step 7: Commit.** `git commit -am "feat(prompt): surface selected technique in prompt-engineering"`
+
+---
+
+## Stage B — First-class worked cards (1605 Phase 2)
+
+### Task 4: Worked-example cards for the 7 first-class techniques
+
+**Files:**
+- Create: `src/skills/prompt/technique-examples.ts`
+- Modify: `src/skills/prompt/technique-selector.ts` (expose `exampleRef` through selection — add `exampleRef: primary.exampleRef ?? null` to the return)
+- Modify: `src/skills/prompt/prompt-engineering.ts` (emit a `worked-example` artifact when the selected technique has a card)
+- Test: `src/tests/skills/prompt/technique-examples.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface TechniqueCard { id: string; input: unknown; expectedOutput: unknown; description: string; }`
+  - `const TECHNIQUE_CARDS: Record<string, TechniqueCard>` keyed by technique id (7 keys)
+  - `function getTechniqueCard(id: string): TechniqueCard | undefined`
+
+**Artifact-kind decision:** default to `buildWorkedExampleArtifact` (its `input`/`expectedOutput` are `unknown`, expressive enough for reasoning traces). Only if a reviewer finds a technique's contract genuinely inexpressible do we add a new `SkillArtifact` kind — deferred unless proven necessary during this task.
+
+- [ ] **Step 1: Write the failing test:**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { TECHNIQUE_CARDS, getTechniqueCard } from "../../../skills/prompt/technique-examples.js";
+import { TECHNIQUE_CATALOG } from "../../../skills/prompt/technique-catalog.js";
+
+describe("technique-examples", () => {
+	it("has a card for every first-class technique", () => {
+		const firstClass = TECHNIQUE_CATALOG.filter((t) => t.tier === "first-class").map((t) => t.id);
+		for (const id of firstClass) expect(getTechniqueCard(id), id).toBeDefined();
+		expect(Object.keys(TECHNIQUE_CARDS)).toHaveLength(firstClass.length);
+	});
+
+	it("every card carries input, expectedOutput, and description", () => {
+		for (const card of Object.values(TECHNIQUE_CARDS)) {
+			expect(card.input).toBeDefined();
+			expect(card.expectedOutput).toBeDefined();
+			expect(card.description.length).toBeGreaterThan(0);
+		}
+	});
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement `technique-examples.ts`** with 7 typed cards (react, rag, reflexion, tree-of-thoughts, pal, self-consistency, meta-prompting), each a concise worked input→output. Header credits universal-creator's `skills/shared/examples/*.prompt.md`.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Emit the card** in `prompt-engineering.ts` — when `selection.exampleRef` resolves, push `buildWorkedExampleArtifact(card.id + " worked example", card.input, card.expectedOutput, card.description)`. Add a test asserting a first-class selection emits an extra `worked-example` artifact.
+- [ ] **Step 6: Run prompt tests — expect PASS.** `npx vitest run src/tests/skills/prompt/`
+- [ ] **Step 7: Commit.** `git commit -am "feat(prompt): worked-example cards for 7 first-class techniques"`
+
+---
+
+## Stage C — Catalog-only labels (1605 Phase 3)
+
+Already delivered by Task 1 (the 5 catalog-only entries ship in the same file). No new task — this stage is satisfied when Task 1's test asserts all 12 ids and the 5 catalog-only tiers are present.
+
+- [ ] **Step 1: Add an assertion to `technique-catalog.test.ts`** that the 5 catalog-only ids are exactly `["cot","few-shot","generate-knowledge","prompt-chaining","zero-shot"]`. Run — expect PASS. Commit `test(prompt): assert catalog-only decision space complete`.
+
+---
+
+## Stage D — Escalation graph (1605 Phase 4)
+
+Escalation edges live in `escalatesTo` (Task 1) and surface in the selector rationale (Task 2). This stage adds explicit coverage + a docs boundary note.
+
+### Task 5: Escalation integrity + rationale surfacing
+
+**Files:**
+- Modify: `src/tests/skills/prompt/technique-selector.test.ts`
+
+- [ ] **Step 1: Add tests** that the selector rationale mentions "escalating" for a technique with `escalatesTo`, and that no escalation edge forms a self-loop (`t.id ∉ t.escalatesTo`). Run — expect FAIL if self-loop present, else adjust.
+- [ ] **Step 2: Implement** any fix needed in the catalog data. Run — expect PASS.
+- [ ] **Step 3: Commit.** `test(prompt): escalation edges surface in rationale, no self-loops`
+
+**Boundary note (for Stage E docs):** techniques are not public tools, so edges are NOT added to `src/generated/graph/**`; they live in catalog data + selector output only.
+
+---
+
+## Stage E — Docs, codegen, gates (1605 Phase 5)
+
+### Task 6: Prompting docs + codegen + full gate
+
+**Files:**
+- Modify: `docs/src/content/docs/skills/prompting.md`
+
+- [ ] **Step 1: Document** the catalog (12 techniques, 3 tiers), the deterministic selector (category + primary/supplementary + rationale, no sampler), the escalation model, the deferred-6 with their infra prerequisite, and MIT attribution to `Anselmoo/universal-creator`. (Hand-written file; no codegen needed for it.)
+- [ ] **Step 2: Regenerate** (only if any spec metadata changed): `npm run build && python3 scripts/generate-tool-definitions.py && npm run generate:skill-docs`.
+- [ ] **Step 3: Drift check.** `npm run check:generated` — expect no diff. If diff appears, it means a source spec changed and the regen must be committed (never hand-edit generated files).
+- [ ] **Step 4: Matrix + quality.** `python3 scripts/verify_matrix.py` and `npm run quality` — expect green.
+- [ ] **Step 5: Full test.** `npm test` — expect green.
+- [ ] **Step 6: Commit.** `git commit -am "docs(prompt): document technique catalog + selector (1605 Phase 5)"`
+
+---
+
+## Stage F — Serena symbol grounding (1601)
+
+### Task 7: Thread `serena` into SkillExecutionRuntime
+
+**Files:**
+- Modify: `src/contracts/runtime.ts` (add `serena?: SerenaClient` to `SkillExecutionRuntime`)
+- Modify: skill-registry (`SkillRegistry.execute()` builds `skillRuntime` — add `serena` passthrough from `WorkflowExecutionRuntime`)
+- Modify: `src/tests/skills/test-helpers.ts` (`createMockSkillRuntime` accepts optional `serena`)
+
+**Interfaces:**
+- Consumes: `SerenaClient` from `src/serena/client.js` (`query({ kind: "find_symbol" | "find_references" | "overview" })`).
+- Produces: `context.runtime.serena?: SerenaClient` available to any skill handler.
+
+- [ ] **Step 1: Write a failing test** in a new `src/tests/skills/shared/serena-grounding.test.ts` that a skill runtime can carry a mock `serena` and a handler reads it. (Red: property doesn't exist on the type.)
+- [ ] **Step 2: Run — expect FAIL (type error / undefined).**
+- [ ] **Step 3: Add `serena?: SerenaClient`** to `SkillExecutionRuntime` in `src/contracts/runtime.ts`; thread it through the registry's `skillRuntime` builder (mirror how `WorkflowExecutionRuntime.serena` already exists); extend `createMockSkillRuntime` to pass it through like `workspace`.
+- [ ] **Step 4: Run — expect PASS.** Use `serena` MCP `find_symbol`/`find_referencing_symbols` to locate the exact registry build site and referencing tests before editing.
+- [ ] **Step 5: Commit.** `feat(grounding): thread SerenaClient into SkillExecutionRuntime`
+
+### Task 8: `resolveSymbolGrounding()` — bounded, never-throws
+
+**Files:**
+- Modify: `src/skills/shared/workspace-grounding.ts`
+- Modify: `src/tests/skills/shared/workspace-grounding.test.ts`
+
+**Interfaces:**
+- Produces: `async function resolveSymbolGrounding(context: SkillExecutionContext, opts?: { maxSymbols?: number }): Promise<RecommendationItem[]>` — queries `context.runtime.serena` for symbols/refs the request did NOT name; returns `[]` when serena absent or on any error; caps at `maxSymbols` (default 3); each item `groundingScope: "workspace"`, `evidenceAnchors: [symbolRef...]`.
+
+- [ ] **Step 1: Write failing tests** — (a) with a mock serena returning a symbol, `resolveSymbolGrounding` returns a `RecommendationItem` citing it in `evidenceAnchors`; (b) with `serena` undefined, returns `[]`; (c) when the mock throws, returns `[]` (never propagates).
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** following the existing `readReferencedFiles` bounded/swallow pattern (cap, try/catch → `[]`).
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Wire into 1 skill** (e.g. `debug-root-cause`) opt-in: append `resolveSymbolGrounding` results to its recommendations. Add a test that the skill degrades gracefully with no serena.
+- [ ] **Step 6: Run + commit.** `feat(grounding): additive Serena symbol grounding (1601 strong version)`
+
+---
+
+## Stage G — Auto-mode verify + audit + harden (1445)
+
+### Task 9: Lock the shipped 1445 invariants
+
+**Files:**
+- Create/Modify: `src/tests/tools/tool-surface-manifest.test.ts`
+- Reference: `src/tools/shared/tool-surface-manifest.ts`, `src/instructions/instruction-specs.ts`, `src/cli.ts`
+
+- [ ] **Step 1: Check for existing assertions** (`grep` for `session-start`, `DISABLE_ADAPTIVE_ROUTING`, `SLIM_SURFACE_TOOLS` in tests). Only add what's missing.
+- [ ] **Step 2: Write regression tests** (red if any invariant regressed):
+  - `meta-routing` spec has `reactivationPolicy === "session-start"`.
+  - `computeEffectiveHiddenTools()` hides `routing-adapt` iff `DISABLE_ADAPTIVE_ROUTING==="true"` (visible by default).
+  - `filterToSlimSurface([...], {})` returns only `task-bootstrap` + `meta-routing`; with `MCP_FULL_SURFACE:"true"` returns all.
+  - CLI `buildHookJson("vscode")` includes both `SessionStart` and `PreToolUse`.
+- [ ] **Step 3: Run — expect PASS** (these are already implemented; tests should go green immediately, proving the invariants hold).
+- [ ] **Step 4: Commit.** `test(auto-mode): lock 1445 session-start/opt-out/slim/hooks invariants`
+
+### Task 10: Description-field audit (item 5)
+
+**Files:**
+- Modify: `src/instructions/instruction-specs.ts`
+
+- [ ] **Step 1: Audit** each `description` toward the `system-design` pattern: explicit trigger phrases + a named anti-pattern ("do NOT use for …") + a one-line companion hint. Edit source only.
+- [ ] **Step 2: Regenerate.** `npm run build && python3 scripts/generate-tool-definitions.py && npm run generate:skill-docs`.
+- [ ] **Step 3: Drift + matrix.** `npm run check:generated` (commit regenerated files) and `python3 scripts/verify_matrix.py`.
+- [ ] **Step 4: Harden via dogfood.** Rebuild; call local `ai-agent-guidelines` `meta-routing` with 3 representative symptoms ("this is broken", "design the architecture", "write tests") and confirm the tightened descriptions route as intended.
+- [ ] **Step 5: Commit.** `feat(auto-mode): tighten instruction descriptions to trigger-phrase pattern (1445 item 5)`
+
+---
+
+## Final integration
+
+### Task 11: Full-suite green + PR
+
+- [ ] **Step 1:** `npm run build && npm test` — all green.
+- [ ] **Step 2:** `npm run quality && npm run check:generated` — green, no drift.
+- [ ] **Step 3:** `/claude-automation-recommender` — adopt any fitting hooks (codegen-drift guard, biome-on-edit) for this PR size.
+- [ ] **Step 4:** Open PR via `github` MCP; body cross-links #1605, #1601, #1445; notes 1445 was found substantially complete (verify + audit + harden); lists deferred 1605 Phases 6–7 as follow-ups.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** 1605 Phases 1–5 → Tasks 1–6; deferred Phases 6–7 noted in Task 11. 1601 → Tasks 7–8. 1445 verify/audit/harden → Tasks 9–10.
+- **Type consistency:** `TechniqueEntry`/`TechniqueSelection`/`TechniqueCard` field names are used identically across Tasks 1–4 and the tests. `resolveSymbolGrounding` signature matches its test and its wire-in.
+- **Determinism:** selector uses stable sort + keyword scoring, no time/random — asserted by the "same input → same output" test.
+- **Artifact order:** baseline prefix preserved; technique artifacts appended only for confident selections (Stage 0 plain-request test guards this).

--- a/src/contracts/runtime.ts
+++ b/src/contracts/runtime.ts
@@ -247,6 +247,12 @@ export interface SkillExecutionRuntime {
 	 * when undefined or when any call throws.
 	 */
 	workspace?: WorkspaceReader;
+	/**
+	 * Optional Serena client seam.  Skill handlers should access this via
+	 * `context.runtime.serena?.query(...)` and must degrade gracefully when
+	 * undefined.  Populated from `WorkflowExecutionRuntime.serena` when present.
+	 */
+	serena?: import("../serena/client.js").SerenaClient;
 }
 
 export interface WorkflowExecutionRuntime {

--- a/src/generated/instructions/debug.ts
+++ b/src/generated/instructions/debug.ts
@@ -9,7 +9,7 @@ export const instructionManifest: InstructionManifestEntry = {
 	aliases: [],
 	displayName: "Debug: Diagnose and Fix Problems",
 	description:
-		"Use when something is broken, producing wrong output, crashing, behaving unexpectedly, or when you need to trace a failure to its root cause. Triggers: 'something is broken', 'this is failing', 'why does this crash', 'unexpected output', 'trace this error', 'find the bug'.",
+		"Use when something is broken, producing wrong output, crashing, behaving unexpectedly, or when you need to trace a failure to its root cause. Do NOT use for adding new functionality (use feature-implement) or for broad code-quality improvement (use code-refactor). Triggers: 'something is broken', 'this is failing', 'why does this crash', 'unexpected output', 'trace this error', 'find the bug'.",
 	sourcePath: "src/instructions/instruction-specs.ts#debug",
 	mission:
 		"Diagnose and fix problems: reproduce → locate → understand → fix → prevent recurrence.",

--- a/src/generated/instructions/design.ts
+++ b/src/generated/instructions/design.ts
@@ -9,7 +9,7 @@ export const instructionManifest: InstructionManifestEntry = {
 	aliases: [],
 	displayName: "Design: Architecture and System Design",
 	description:
-		"Use when designing a new system, service, agent architecture, data pipeline, or infrastructure component; evaluating architectural options; making build-vs-buy decisions; or establishing constraints and tradeoffs before coding begins. This is the primary tool for architecture work — use this instead of adapt or orchestrate for system design tasks. Companion tools: use `graph-visualize` (chain-graph, skill-graph) to inspect the instruction chain and skill topology. Triggers: 'design this system', 'architecture for', 'how should we structure', 'system design', 'greenfield', 'architectural decision'.",
+		"Use when designing a new system, service, agent architecture, data pipeline, or infrastructure component; evaluating architectural options; making build-vs-buy decisions; or establishing constraints and tradeoffs before coding begins. This is the primary tool for architecture work — use this instead of adapt or orchestrate for system design tasks. Do NOT use for implementing the design (use feature-implement) or for comparing tool options without a design decision (use evidence-research). Companion tools: use `graph-visualize` (chain-graph, skill-graph) to inspect the instruction chain and skill topology. Triggers: 'design this system', 'architecture for', 'how should we structure', 'system design', 'greenfield', 'architectural decision'.",
 	sourcePath: "src/instructions/instruction-specs.ts#design",
 	mission:
 		"Understand constraints → explore options → decide → document. Produces a decision-backed architecture.",

--- a/src/generated/instructions/document.ts
+++ b/src/generated/instructions/document.ts
@@ -9,7 +9,7 @@ export const instructionManifest: InstructionManifestEntry = {
 	aliases: [],
 	displayName: "Document: Generate Documentation Artifacts",
 	description:
-		"Use when generating API reference documentation, README files, operational runbooks, postmortems, technical guides, or any other documentation artifact. Triggers: 'write documentation', 'generate docs', 'create a README', 'document this API', 'write a runbook', 'document this module', 'postmortem for', 'technical guide'.",
+		"Use when generating API reference documentation, README files, operational runbooks, postmortems, technical guides, or any other documentation artifact. Do NOT use for reviewing code or checking its quality (use code-review) or for writing code that happens to be documented (use feature-implement). Triggers: 'write documentation', 'generate docs', 'create a README', 'document this API', 'write a runbook', 'document this module', 'postmortem for', 'technical guide'.",
 	sourcePath: "src/instructions/instruction-specs.ts#document",
 	mission:
 		"Identify audience → choose format → generate content → publish. Every doc is audience-targeted.",

--- a/src/generated/instructions/evaluate.ts
+++ b/src/generated/instructions/evaluate.ts
@@ -9,7 +9,7 @@ export const instructionManifest: InstructionManifestEntry = {
 	aliases: [],
 	displayName: "Evaluate: Benchmark and Assess Quality",
 	description:
-		"Use when benchmarking AI system quality, measuring output consistency, running eval suites, comparing model versions, detecting quality regressions, grading outputs against rubrics, or generating evaluation reports. Triggers: 'benchmark this', 'run evals', 'measure quality', 'compare model outputs', 'quality gate', 'detect regression', 'grade these outputs', 'eval suite'.",
+		"Use when benchmarking AI system quality, measuring output consistency, running eval suites, comparing model versions, detecting quality regressions, grading outputs against rubrics, or generating evaluation reports. Do NOT use for reviewing code quality (use code-review) or for writing the tests themselves (use test-verify). Triggers: 'benchmark this', 'run evals', 'measure quality', 'compare model outputs', 'quality gate', 'detect regression', 'grade these outputs', 'eval suite'.",
 	sourcePath: "src/instructions/instruction-specs.ts#evaluate",
 	mission:
 		"Define metrics → measure → compare → report → act. Every evaluation produces a decision or action.",

--- a/src/generated/instructions/implement.ts
+++ b/src/generated/instructions/implement.ts
@@ -9,7 +9,7 @@ export const instructionManifest: InstructionManifestEntry = {
 	aliases: ["implement"],
 	displayName: "Implement: Build New Feature or Tool",
 	description:
-		"Use when building a new tool, feature, endpoint, agent, workflow component, or capability from scratch. Covers the full lifecycle: requirements gathering, design decisions, code structure, tests, governance checks, and documentation. Triggers: 'build this', 'add a new', 'create a tool', 'implement feature', 'new functionality'.",
+		"Use when building a new tool, feature, endpoint, agent, workflow component, or capability from scratch. Covers the full lifecycle: requirements gathering, design decisions, code structure, tests, governance checks, and documentation. Do NOT use for fixing a broken existing feature (use issue-debug) or for pure design decisions before coding begins (use system-design). Triggers: 'build this', 'add a new', 'create a tool', 'implement feature', 'new functionality'.",
 	sourcePath: "src/instructions/instruction-specs.ts#implement",
 	mission:
 		"Build new tools or features end-to-end: requirements → design → code → tests → docs.",

--- a/src/generated/instructions/prompt-engineering.ts
+++ b/src/generated/instructions/prompt-engineering.ts
@@ -9,7 +9,7 @@ export const instructionManifest: InstructionManifestEntry = {
 	aliases: [],
 	displayName: "Prompt Engineering: Build, Evaluate, and Optimize Prompts",
 	description:
-		"Use when writing a new system prompt, building a prompt template, improving an existing prompt that is failing or hallucinating, versioning prompts, chaining prompts into pipelines, calibrating agent autonomy levels, or evaluating prompt quality against benchmarks. Triggers: 'write a system prompt', 'improve this prompt', 'prompt is hallucinating', 'prompt template', 'chain these prompts', 'calibrate autonomy', 'prompt version'.",
+		"Use when writing a new system prompt, building a prompt template, improving an existing prompt that is failing or hallucinating, versioning prompts, chaining prompts into pipelines, calibrating agent autonomy levels, or evaluating prompt quality against benchmarks. Do NOT use for measuring output quality at scale (use quality-evaluate) or for implementing the agent or tool being prompted (use feature-implement). Triggers: 'write a system prompt', 'improve this prompt', 'prompt is hallucinating', 'prompt template', 'chain these prompts', 'calibrate autonomy', 'prompt version'.",
 	sourcePath: "src/instructions/instruction-specs.ts#prompt-engineering",
 	mission:
 		"Structure → test → refine → version. Every prompt is a versioned, tested artifact.",

--- a/src/generated/instructions/refactor.ts
+++ b/src/generated/instructions/refactor.ts
@@ -9,7 +9,7 @@ export const instructionManifest: InstructionManifestEntry = {
 	aliases: [],
 	displayName: "Refactor: Improve Existing Code Safely",
 	description:
-		"Use when improving existing code quality, reducing technical debt, eliminating coupling, splitting oversized modules, improving performance, or hardening security of existing code. Triggers: 'refactor this', 'reduce tech debt', 'clean up', 'improve code quality', 'split this module', 'too complex'.",
+		"Use when improving existing code quality, reducing technical debt, eliminating coupling, splitting oversized modules, improving performance, or hardening security of existing code. Do NOT use for adding new functionality (use feature-implement) or for diagnosing why code is broken (use issue-debug). Triggers: 'refactor this', 'reduce tech debt', 'clean up', 'improve code quality', 'split this module', 'too complex'.",
 	sourcePath: "src/instructions/instruction-specs.ts#refactor",
 	mission:
 		"Improve existing code: measure → prioritize → transform → verify. Never break working behavior.",

--- a/src/generated/instructions/review.ts
+++ b/src/generated/instructions/review.ts
@@ -9,7 +9,7 @@ export const instructionManifest: InstructionManifestEntry = {
 	aliases: ["review"],
 	displayName: "Review: Code, Quality, and Security Review",
 	description:
-		"Use when reviewing existing code for quality, security vulnerabilities, correctness, maintainability, API surface hygiene, compliance adherence, or evaluation output grading. This is the primary tool for code review and quality assessment — use this instead of adapt or orchestrate for review tasks. Triggers: 'review this code', 'code review', 'check for security issues', 'quality review', 'audit this', 'grade this output', 'inspect this PR'.",
+		"Use when reviewing existing code for quality, security vulnerabilities, correctness, maintainability, API surface hygiene, compliance adherence, or evaluation output grading. This is the primary tool for code review and quality assessment — use this instead of adapt or orchestrate for review tasks. Do NOT use for making the changes themselves (use code-refactor or feature-implement) or for compliance and policy enforcement (use policy-govern). Triggers: 'review this code', 'code review', 'check for security issues', 'quality review', 'audit this', 'grade this output', 'inspect this PR'.",
 	sourcePath: "src/instructions/instruction-specs.ts#review",
 	mission:
 		"Inspect → grade → recommend → close the loop. Every review produces actionable findings.",

--- a/src/generated/instructions/testing.ts
+++ b/src/generated/instructions/testing.ts
@@ -9,7 +9,7 @@ export const instructionManifest: InstructionManifestEntry = {
 	aliases: [],
 	displayName: "Testing: Write, Run, and Verify Tests",
 	description:
-		"Use when writing unit tests, integration tests, or eval test cases; measuring test coverage; closing coverage gaps; verifying correctness of AI outputs; preventing regressions; or setting up testing infrastructure. Triggers: 'write tests', 'add tests', 'test coverage', 'regression tests', 'eval test cases', 'test this', 'verify this works'.",
+		"Use when writing unit tests, integration tests, or eval test cases; measuring test coverage; closing coverage gaps; verifying correctness of AI outputs; preventing regressions; or setting up testing infrastructure. Do NOT use for debugging why a test fails (use issue-debug) or for benchmarking AI output quality (use quality-evaluate). Triggers: 'write tests', 'add tests', 'test coverage', 'regression tests', 'eval test cases', 'test this', 'verify this works'.",
 	sourcePath: "src/instructions/instruction-specs.ts#testing",
 	mission:
 		"Write, run, and verify tests: define what to prove → choose strategy → implement → measure coverage → close gaps → prevent regression.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,12 +128,12 @@ export function createRuntime(
 	const instructionRegistry = new InstructionRegistry();
 	const skillRegistry = new SkillRegistry();
 	const modelRouter = new ModelRouter();
+	const serena = options.serena ?? resolveSerenaClient();
 	const integratedRuntime = createIntegratedRuntime(
 		skillRegistry,
-		{ modelRouter },
+		{ modelRouter, serena },
 		{},
 	);
-	const serena = options.serena ?? resolveSerenaClient();
 	return {
 		sessionId: createSessionId(),
 		workspaceRoot: resolveWorkspaceRoot(),

--- a/src/instructions/instruction-specs.ts
+++ b/src/instructions/instruction-specs.ts
@@ -59,7 +59,7 @@ export const INSTRUCTION_SPECS: InstructionSpecDefinition[] = [
 		toolName: "system-design",
 		displayName: "Design: Architecture and System Design",
 		description:
-			"Use when designing a new system, service, agent architecture, data pipeline, or infrastructure component; evaluating architectural options; making build-vs-buy decisions; or establishing constraints and tradeoffs before coding begins. This is the primary tool for architecture work — use this instead of adapt or orchestrate for system design tasks. Companion tools: use `graph-visualize` (chain-graph, skill-graph) to inspect the instruction chain and skill topology. Triggers: 'design this system', 'architecture for', 'how should we structure', 'system design', 'greenfield', 'architectural decision'.",
+			"Use when designing a new system, service, agent architecture, data pipeline, or infrastructure component; evaluating architectural options; making build-vs-buy decisions; or establishing constraints and tradeoffs before coding begins. This is the primary tool for architecture work — use this instead of adapt or orchestrate for system design tasks. Do NOT use for implementing the design (use feature-implement) or for comparing tool options without a design decision (use evidence-research). Companion tools: use `graph-visualize` (chain-graph, skill-graph) to inspect the instruction chain and skill topology. Triggers: 'design this system', 'architecture for', 'how should we structure', 'system design', 'greenfield', 'architectural decision'.",
 		mission:
 			"Understand constraints → explore options → decide → document. Produces a decision-backed architecture.",
 		chainTo: ["feature-implement", "policy-govern"],
@@ -74,7 +74,7 @@ export const INSTRUCTION_SPECS: InstructionSpecDefinition[] = [
 		aliases: ["implement"],
 		displayName: "Implement: Build New Feature or Tool",
 		description:
-			"Use when building a new tool, feature, endpoint, agent, workflow component, or capability from scratch. Covers the full lifecycle: requirements gathering, design decisions, code structure, tests, governance checks, and documentation. Triggers: 'build this', 'add a new', 'create a tool', 'implement feature', 'new functionality'.",
+			"Use when building a new tool, feature, endpoint, agent, workflow component, or capability from scratch. Covers the full lifecycle: requirements gathering, design decisions, code structure, tests, governance checks, and documentation. Do NOT use for fixing a broken existing feature (use issue-debug) or for pure design decisions before coding begins (use system-design). Triggers: 'build this', 'add a new', 'create a tool', 'implement feature', 'new functionality'.",
 		mission:
 			"Build new tools or features end-to-end: requirements → design → code → tests → docs.",
 		chainTo: ["test-verify", "code-review"],
@@ -103,7 +103,7 @@ export const INSTRUCTION_SPECS: InstructionSpecDefinition[] = [
 		aliases: ["review"],
 		displayName: "Review: Code, Quality, and Security Review",
 		description:
-			"Use when reviewing existing code for quality, security vulnerabilities, correctness, maintainability, API surface hygiene, compliance adherence, or evaluation output grading. This is the primary tool for code review and quality assessment — use this instead of adapt or orchestrate for review tasks. Triggers: 'review this code', 'code review', 'check for security issues', 'quality review', 'audit this', 'grade this output', 'inspect this PR'.",
+			"Use when reviewing existing code for quality, security vulnerabilities, correctness, maintainability, API surface hygiene, compliance adherence, or evaluation output grading. This is the primary tool for code review and quality assessment — use this instead of adapt or orchestrate for review tasks. Do NOT use for making the changes themselves (use code-refactor or feature-implement) or for compliance and policy enforcement (use policy-govern). Triggers: 'review this code', 'code review', 'check for security issues', 'quality review', 'audit this', 'grade this output', 'inspect this PR'.",
 		mission:
 			"Inspect → grade → recommend → close the loop. Every review produces actionable findings.",
 		chainTo: ["policy-govern", "code-refactor", "test-verify"],
@@ -131,7 +131,7 @@ export const INSTRUCTION_SPECS: InstructionSpecDefinition[] = [
 		toolName: "issue-debug",
 		displayName: "Debug: Diagnose and Fix Problems",
 		description:
-			"Use when something is broken, producing wrong output, crashing, behaving unexpectedly, or when you need to trace a failure to its root cause. Triggers: 'something is broken', 'this is failing', 'why does this crash', 'unexpected output', 'trace this error', 'find the bug'.",
+			"Use when something is broken, producing wrong output, crashing, behaving unexpectedly, or when you need to trace a failure to its root cause. Do NOT use for adding new functionality (use feature-implement) or for broad code-quality improvement (use code-refactor). Triggers: 'something is broken', 'this is failing', 'why does this crash', 'unexpected output', 'trace this error', 'find the bug'.",
 		mission:
 			"Diagnose and fix problems: reproduce → locate → understand → fix → prevent recurrence.",
 		chainTo: ["test-verify", "code-refactor", "policy-govern"],
@@ -145,7 +145,7 @@ export const INSTRUCTION_SPECS: InstructionSpecDefinition[] = [
 		toolName: "code-refactor",
 		displayName: "Refactor: Improve Existing Code Safely",
 		description:
-			"Use when improving existing code quality, reducing technical debt, eliminating coupling, splitting oversized modules, improving performance, or hardening security of existing code. Triggers: 'refactor this', 'reduce tech debt', 'clean up', 'improve code quality', 'split this module', 'too complex'.",
+			"Use when improving existing code quality, reducing technical debt, eliminating coupling, splitting oversized modules, improving performance, or hardening security of existing code. Do NOT use for adding new functionality (use feature-implement) or for diagnosing why code is broken (use issue-debug). Triggers: 'refactor this', 'reduce tech debt', 'clean up', 'improve code quality', 'split this module', 'too complex'.",
 		mission:
 			"Improve existing code: measure → prioritize → transform → verify. Never break working behavior.",
 		chainTo: ["test-verify", "code-review"],
@@ -159,7 +159,7 @@ export const INSTRUCTION_SPECS: InstructionSpecDefinition[] = [
 		toolName: "test-verify",
 		displayName: "Testing: Write, Run, and Verify Tests",
 		description:
-			"Use when writing unit tests, integration tests, or eval test cases; measuring test coverage; closing coverage gaps; verifying correctness of AI outputs; preventing regressions; or setting up testing infrastructure. Triggers: 'write tests', 'add tests', 'test coverage', 'regression tests', 'eval test cases', 'test this', 'verify this works'.",
+			"Use when writing unit tests, integration tests, or eval test cases; measuring test coverage; closing coverage gaps; verifying correctness of AI outputs; preventing regressions; or setting up testing infrastructure. Do NOT use for debugging why a test fails (use issue-debug) or for benchmarking AI output quality (use quality-evaluate). Triggers: 'write tests', 'add tests', 'test coverage', 'regression tests', 'eval test cases', 'test this', 'verify this works'.",
 		mission:
 			"Write, run, and verify tests: define what to prove → choose strategy → implement → measure coverage → close gaps → prevent regression.",
 		chainTo: ["code-review", "issue-debug", "quality-evaluate"],
@@ -173,7 +173,7 @@ export const INSTRUCTION_SPECS: InstructionSpecDefinition[] = [
 		toolName: "docs-generate",
 		displayName: "Document: Generate Documentation Artifacts",
 		description:
-			"Use when generating API reference documentation, README files, operational runbooks, postmortems, technical guides, or any other documentation artifact. Triggers: 'write documentation', 'generate docs', 'create a README', 'document this API', 'write a runbook', 'document this module', 'postmortem for', 'technical guide'.",
+			"Use when generating API reference documentation, README files, operational runbooks, postmortems, technical guides, or any other documentation artifact. Do NOT use for reviewing code or checking its quality (use code-review) or for writing code that happens to be documented (use feature-implement). Triggers: 'write documentation', 'generate docs', 'create a README', 'document this API', 'write a runbook', 'document this module', 'postmortem for', 'technical guide'.",
 		mission:
 			"Identify audience → choose format → generate content → publish. Every doc is audience-targeted.",
 		chainTo: ["code-review", "enterprise-strategy"],
@@ -187,7 +187,7 @@ export const INSTRUCTION_SPECS: InstructionSpecDefinition[] = [
 		toolName: "quality-evaluate",
 		displayName: "Evaluate: Benchmark and Assess Quality",
 		description:
-			"Use when benchmarking AI system quality, measuring output consistency, running eval suites, comparing model versions, detecting quality regressions, grading outputs against rubrics, or generating evaluation reports. Triggers: 'benchmark this', 'run evals', 'measure quality', 'compare model outputs', 'quality gate', 'detect regression', 'grade these outputs', 'eval suite'.",
+			"Use when benchmarking AI system quality, measuring output consistency, running eval suites, comparing model versions, detecting quality regressions, grading outputs against rubrics, or generating evaluation reports. Do NOT use for reviewing code quality (use code-review) or for writing the tests themselves (use test-verify). Triggers: 'benchmark this', 'run evals', 'measure quality', 'compare model outputs', 'quality gate', 'detect regression', 'grade these outputs', 'eval suite'.",
 		mission:
 			"Define metrics → measure → compare → report → act. Every evaluation produces a decision or action.",
 		chainTo: ["prompt-engineering", "code-refactor", "policy-govern"],
@@ -201,7 +201,7 @@ export const INSTRUCTION_SPECS: InstructionSpecDefinition[] = [
 		toolName: "prompt-engineering",
 		displayName: "Prompt Engineering: Build, Evaluate, and Optimize Prompts",
 		description:
-			"Use when writing a new system prompt, building a prompt template, improving an existing prompt that is failing or hallucinating, versioning prompts, chaining prompts into pipelines, calibrating agent autonomy levels, or evaluating prompt quality against benchmarks. Triggers: 'write a system prompt', 'improve this prompt', 'prompt is hallucinating', 'prompt template', 'chain these prompts', 'calibrate autonomy', 'prompt version'.",
+			"Use when writing a new system prompt, building a prompt template, improving an existing prompt that is failing or hallucinating, versioning prompts, chaining prompts into pipelines, calibrating agent autonomy levels, or evaluating prompt quality against benchmarks. Do NOT use for measuring output quality at scale (use quality-evaluate) or for implementing the agent or tool being prompted (use feature-implement). Triggers: 'write a system prompt', 'improve this prompt', 'prompt is hallucinating', 'prompt template', 'chain these prompts', 'calibrate autonomy', 'prompt version'.",
 		mission:
 			"Structure → test → refine → version. Every prompt is a versioned, tested artifact.",
 		chainTo: ["quality-evaluate", "policy-govern"],

--- a/src/skills/debug/debug-root-cause.ts
+++ b/src/skills/debug/debug-root-cause.ts
@@ -20,6 +20,7 @@ import {
 	type ContentProbe,
 	matchProbes,
 	readReferencedFiles,
+	resolveSymbolGrounding,
 } from "../shared/workspace-grounding.js";
 
 const debugRootCauseInputSchema = baseSkillInputSchema.extend({
@@ -154,11 +155,14 @@ const debugRootCauseHandler: SkillHandler = {
 			}),
 		);
 
+		const serenaRecs = await resolveSymbolGrounding(context);
+
 		return createCapabilityResult(
 			context,
-			`Root Cause Analysis using ${selectedTechnique} (depth: ${maxDepth}) identified ${causalCandidates.length} causal signal category(s): ${causalCandidates.join(", ") || "none detected"}${groundedFiles.length > 0 ? `; grounded in ${groundedFiles.length} referenced file(s)` : ""}.`,
+			`Root Cause Analysis using ${selectedTechnique} (depth: ${maxDepth}) identified ${causalCandidates.length} causal signal category(s): ${causalCandidates.join(", ") || "none detected"}${groundedFiles.length > 0 ? `; grounded in ${groundedFiles.length} referenced file(s)` : ""}${serenaRecs.length > 0 ? `; ${serenaRecs.length} Serena symbol grounding hint(s)` : ""}.`,
 			[
 				...groundedRecs,
+				...serenaRecs,
 				...createFocusRecommendations(
 					`${selectedTechnique} causal analysis`,
 					details,

--- a/src/skills/prompt/prompt-engineering.ts
+++ b/src/skills/prompt/prompt-engineering.ts
@@ -19,6 +19,7 @@ import {
 	parseSkillInput,
 } from "../shared/input-schema.js";
 import { extractRequestSignals } from "../shared/recommendations.js";
+import { getTechniqueCard } from "./technique-examples.js";
 import { selectTechniques } from "./technique-selector.js";
 
 const promptEngineeringInputSchema = baseSkillInputSchema.extend({
@@ -285,7 +286,7 @@ const promptEngineeringHandler: SkillHandler = {
 			artifacts.push(
 				buildComparisonMatrixArtifact(
 					"Technique selection",
-					["Role", "Technique", "Why"],
+					["Role", "Technique", "Category"],
 					[
 						{
 							label: "primary",
@@ -299,6 +300,20 @@ const promptEngineeringHandler: SkillHandler = {
 					selection.rationale,
 				),
 			);
+
+			if (selection.exampleRef) {
+				const card = getTechniqueCard(selection.exampleRef);
+				if (card) {
+					artifacts.push(
+						buildWorkedExampleArtifact(
+							`${card.id} worked example`,
+							card.input,
+							card.expectedOutput,
+							card.description,
+						),
+					);
+				}
+			}
 		}
 
 		return {

--- a/src/skills/prompt/prompt-engineering.ts
+++ b/src/skills/prompt/prompt-engineering.ts
@@ -19,6 +19,7 @@ import {
 	parseSkillInput,
 } from "../shared/input-schema.js";
 import { extractRequestSignals } from "../shared/recommendations.js";
+import { selectTechniques } from "./technique-selector.js";
 
 const promptEngineeringInputSchema = baseSkillInputSchema.extend({
 	options: z
@@ -140,6 +141,13 @@ const promptEngineeringHandler: SkillHandler = {
 		if (signals.hasConstraints) {
 			details.push(
 				`Treat the stated constraints as prompt contract clauses, not optional reminders: ${signals.constraintList.slice(0, 3).join("; ")}. Constraints that live outside the prompt are regularly violated in production use.`,
+			);
+		}
+
+		const selection = selectTechniques(parsed.data);
+		if (selection.confident && selection.primary) {
+			details.push(
+				`Selected technique: ${selection.primary} (${selection.category}). ${selection.rationale} Structural requirements: ${selection.structureRequirements.join(" ")}`,
 			);
 		}
 
@@ -269,6 +277,26 @@ const promptEngineeringHandler: SkillHandler = {
 						`The prompt satisfies: ${parsed.data.successCriteria}`,
 					],
 					"Criteria for prompt asset acceptance.",
+				),
+			);
+		}
+
+		if (selection.confident && selection.primary) {
+			artifacts.push(
+				buildComparisonMatrixArtifact(
+					"Technique selection",
+					["Role", "Technique", "Why"],
+					[
+						{
+							label: "primary",
+							values: [selection.primary, selection.category],
+						},
+						...selection.supplementary.map((id) => ({
+							label: "supplementary",
+							values: [id, "same-category support"],
+						})),
+					],
+					selection.rationale,
 				),
 			);
 		}

--- a/src/skills/prompt/technique-catalog.ts
+++ b/src/skills/prompt/technique-catalog.ts
@@ -202,6 +202,7 @@ export const TECHNIQUE_CATALOG: readonly TechniqueEntry[] = [
 			"Require the model to output a revised or improved prompt before answering.",
 			"Specify the criteria used to judge whether the new prompt is better.",
 			"Separate the prompt-critique step from the task-execution step.",
+			"Define the stop condition: keep the original prompt if the regenerated one does not beat it on the eval.",
 		],
 		useCase:
 			"Situations where the initial prompt is under-specified or ambiguous; the model rewrites the prompt before executing the task.",

--- a/src/skills/prompt/technique-catalog.ts
+++ b/src/skills/prompt/technique-catalog.ts
@@ -1,0 +1,277 @@
+/**
+ * Prompt-technique catalog — ported (MIT) from Anselmoo/universal-creator's
+ * skills/shared/techniques.json. Data-only: the deterministic selector
+ * (technique-selector.ts) ranks these; no sampler, no per-technique tools.
+ */
+
+export type TechniqueCategory =
+	| "reasoning"
+	| "retrieval"
+	| "agentic"
+	| "self-improvement"
+	| "baseline";
+
+export type TechniqueTier = "first-class" | "catalog-only";
+
+export interface TechniqueEntry {
+	id: string;
+	name: string;
+	category: TechniqueCategory;
+	tier: TechniqueTier;
+	/** Keywords for deterministic ranking (mirrors ROUTING_KEYWORDS pattern). */
+	keywords: readonly string[];
+	/** 3–5 structural requirements the technique imposes on the prompt. */
+	structureSignals: readonly string[];
+	useCase: string;
+	/** technique→technique escalation edges (Stage D). */
+	escalatesTo: readonly string[];
+	/** Pointer to a worked card in technique-examples.ts (first-class only). */
+	exampleRef?: string;
+}
+
+export const TECHNIQUE_CATALOG: readonly TechniqueEntry[] = [
+	{
+		id: "react",
+		name: "ReAct (Reason + Act)",
+		category: "agentic",
+		tier: "first-class",
+		keywords: ["tool", "agent", "action", "observe", "api", "call", "interact"],
+		structureSignals: [
+			"Interleave Thought → Action → Observation steps explicitly.",
+			"Name the tool/action namespace the model may call.",
+			"Require the model to stop and observe before the next action.",
+			"Define a termination condition (answer found or budget exhausted).",
+		],
+		useCase:
+			"Tasks needing external tool calls with observation between steps.",
+		escalatesTo: ["rag", "reflexion"],
+		exampleRef: "react",
+	},
+	{
+		id: "cot",
+		name: "Chain-of-Thought",
+		category: "reasoning",
+		tier: "catalog-only",
+		keywords: ["reason", "step by step", "think", "explain", "logic"],
+		structureSignals: [
+			"Ask for explicit intermediate reasoning before the answer.",
+			"Separate the reasoning trace from the final answer field.",
+			"Keep each reasoning step to one inference.",
+		],
+		useCase: "Multi-step reasoning where showing the work improves accuracy.",
+		escalatesTo: ["pal", "self-consistency", "tree-of-thoughts"],
+	},
+	{
+		id: "rag",
+		name: "Retrieval-Augmented Generation",
+		category: "retrieval",
+		tier: "first-class",
+		keywords: [
+			"retrieve",
+			"document",
+			"knowledge base",
+			"source",
+			"citation",
+			"ground",
+		],
+		structureSignals: [
+			"Specify retrieval order: system rules → task → retrieved evidence.",
+			"Require answers to cite the retrieved source ids.",
+			"Define behavior when retrieval returns nothing relevant.",
+			"Bound context window usage for retrieved chunks.",
+		],
+		useCase: "Answers must be grounded in an external corpus with citations.",
+		escalatesTo: ["reflexion"],
+		exampleRef: "rag",
+	},
+	{
+		id: "self-consistency",
+		name: "Self-Consistency",
+		category: "reasoning",
+		tier: "first-class",
+		keywords: ["consistent", "vote", "majority", "sample", "reliability"],
+		structureSignals: [
+			"Specify the number of independent samples to generate.",
+			"Define the aggregation rule (majority vote or weighted average).",
+			"Instruct the model to produce each sample independently without referencing prior outputs.",
+			"Include a tie-breaking rule when the majority is not clear.",
+		],
+		useCase:
+			"Improve answer reliability on complex reasoning tasks by sampling multiple diverse solutions and taking the majority vote.",
+		escalatesTo: ["tree-of-thoughts"],
+		exampleRef: "self-consistency",
+	},
+	{
+		id: "tree-of-thoughts",
+		name: "Tree of Thoughts",
+		category: "reasoning",
+		tier: "first-class",
+		keywords: [
+			"explore",
+			"branch",
+			"alternative",
+			"backtrack",
+			"search",
+			"options",
+		],
+		structureSignals: [
+			"Prompt the model to generate multiple candidate thoughts at each step.",
+			"Specify an evaluation criterion to score or rank each branch.",
+			"Require explicit backtracking when a branch is deemed unpromising.",
+			"Define a depth limit or termination condition for the search.",
+			"Separate the generation step from the evaluation step in the prompt structure.",
+		],
+		useCase:
+			"Strategic or combinatorial problems requiring exploration of multiple reasoning branches with pruning and backtracking.",
+		escalatesTo: ["self-consistency"],
+		exampleRef: "tree-of-thoughts",
+	},
+	{
+		id: "pal",
+		name: "Program-Aided Language Models",
+		category: "reasoning",
+		tier: "first-class",
+		keywords: [
+			"calculate",
+			"compute",
+			"math",
+			"code",
+			"program",
+			"arithmetic",
+			"numeric",
+		],
+		structureSignals: [
+			"Direct the model to express the solution as executable code or pseudo-code.",
+			"Separate the code-writing step from the final answer derivation step.",
+			"Specify the execution environment or interpreter context when relevant.",
+			"Require the model to annotate each code block with its mathematical intent.",
+		],
+		useCase:
+			"Arithmetic, mathematical, or algorithmic tasks where delegating computation to code improves accuracy over natural language reasoning.",
+		escalatesTo: ["self-consistency"],
+		exampleRef: "pal",
+	},
+	{
+		id: "generate-knowledge",
+		name: "Generate Knowledge",
+		category: "retrieval",
+		tier: "catalog-only",
+		keywords: ["background", "facts", "recall", "elaborate", "knowledge"],
+		structureSignals: [
+			"Ask the model to first generate relevant background facts before answering.",
+			"Separate the knowledge-generation step from the final answer step.",
+			"Instruct the model to flag generated facts it is uncertain about.",
+		],
+		useCase:
+			"Questions requiring domain background that may not be stated in the prompt; priming the model with self-generated facts before the main task.",
+		escalatesTo: ["rag"],
+	},
+	{
+		id: "reflexion",
+		name: "Reflexion",
+		category: "self-improvement",
+		tier: "first-class",
+		keywords: [
+			"reflect",
+			"self-critique",
+			"improve",
+			"iterate",
+			"feedback",
+			"retry",
+		],
+		structureSignals: [
+			"Define an evaluation function or rubric the model uses to score its own output.",
+			"Require a written self-critique that identifies specific failure modes.",
+			"Specify the maximum number of reflection iterations before stopping.",
+			"Instruct the model to store and reference prior failed attempts in subsequent tries.",
+			"Distinguish the reflection trace from the final answer in the output format.",
+		],
+		useCase:
+			"Iterative self-improvement loop where the model critiques its own prior output, identifies errors, and produces a refined answer.",
+		escalatesTo: ["meta-prompting"],
+		exampleRef: "reflexion",
+	},
+	{
+		id: "meta-prompting",
+		name: "Meta-Prompting",
+		category: "self-improvement",
+		tier: "first-class",
+		keywords: ["meta", "critique the prompt", "regenerate", "refine prompt"],
+		structureSignals: [
+			"Instruct the model to first evaluate the quality of the current prompt.",
+			"Require the model to output a revised or improved prompt before answering.",
+			"Specify the criteria used to judge whether the new prompt is better.",
+			"Separate the prompt-critique step from the task-execution step.",
+		],
+		useCase:
+			"Situations where the initial prompt is under-specified or ambiguous; the model rewrites the prompt before executing the task.",
+		escalatesTo: ["reflexion"],
+		exampleRef: "meta-prompting",
+	},
+	{
+		id: "zero-shot",
+		name: "Zero-Shot Prompting",
+		category: "baseline",
+		tier: "catalog-only",
+		keywords: ["direct", "simple", "single", "quick", "straightforward"],
+		structureSignals: [
+			"State the task clearly with no worked examples.",
+			"Provide all required constraints and output format in the instruction.",
+			"Keep the prompt concise — omit context that would be demonstrated via examples.",
+		],
+		useCase:
+			"Simple, well-defined tasks where the model's pre-trained knowledge is sufficient and no examples are needed.",
+		escalatesTo: ["few-shot"],
+	},
+	{
+		id: "few-shot",
+		name: "Few-Shot Prompting",
+		category: "baseline",
+		tier: "catalog-only",
+		keywords: ["example", "examples", "few-shot", "demonstrate", "sample"],
+		structureSignals: [
+			"Include 2–5 input/output demonstration pairs before the actual task.",
+			"Ensure examples are representative and span the expected variation in inputs.",
+			"Keep the format of each example consistent with the expected final output format.",
+			"Place the actual task query after the last example, not interleaved.",
+		],
+		useCase:
+			"Tasks with a specific output format or style that is easier to show than to describe; demonstrations calibrate the model's output.",
+		escalatesTo: ["cot", "reflexion"],
+	},
+	{
+		id: "prompt-chaining",
+		name: "Prompt Chaining",
+		category: "baseline",
+		tier: "catalog-only",
+		keywords: [
+			"chain",
+			"multi-step",
+			"pipeline",
+			"sequence",
+			"stage",
+			"decompose",
+		],
+		structureSignals: [
+			"Decompose the overall task into a numbered sequence of sub-prompts.",
+			"Pass only the relevant output of each stage as input to the next stage.",
+			"Define a clear hand-off contract (format and fields) between each stage.",
+			"Specify a validation or gate condition before advancing to the next stage.",
+		],
+		useCase:
+			"Complex tasks that benefit from decomposition into sequential stages, where each stage's output feeds the next.",
+		escalatesTo: ["react"],
+	},
+];
+
+const BY_ID = new Map(TECHNIQUE_CATALOG.map((t) => [t.id, t]));
+
+export function getTechnique(id: string): TechniqueEntry | undefined {
+	return BY_ID.get(id);
+}
+
+export function techniquesByCategory(
+	cat: TechniqueCategory,
+): readonly TechniqueEntry[] {
+	return TECHNIQUE_CATALOG.filter((t) => t.category === cat);
+}

--- a/src/skills/prompt/technique-examples.ts
+++ b/src/skills/prompt/technique-examples.ts
@@ -1,0 +1,227 @@
+/**
+ * Worked-example cards for the 7 first-class prompt techniques.
+ *
+ * Cards are ported (MIT) from Anselmoo/universal-creator's
+ * skills/shared/examples/*.prompt.md. Each card pairs a concise task
+ * input with an expected structured output and a short description so
+ * consumers can render a concrete before/after illustration.
+ */
+
+export interface TechniqueCard {
+	id: string;
+	input: unknown;
+	expectedOutput: unknown;
+	description: string;
+}
+
+export const TECHNIQUE_CARDS: Record<string, TechniqueCard> = {
+	react: {
+		id: "react",
+		input: {
+			task: "What is the current weather in Berlin and should I bring an umbrella?",
+			availableTools: [
+				"weather.get(city: string)",
+				"forecast.get(city: string, days: number)",
+			],
+		},
+		expectedOutput: {
+			thought: "I need to look up the current weather in Berlin first.",
+			action: { tool: "weather.get", args: { city: "Berlin" } },
+			observation: "Berlin: 14°C, overcast, 70% chance of rain.",
+			thought2:
+				"Rain is likely. I should also check the forecast to give a confident recommendation.",
+			action2: { tool: "forecast.get", args: { city: "Berlin", days: 1 } },
+			observation2: "Tomorrow: continued rain through the afternoon.",
+			answer:
+				"Yes, bring an umbrella. Berlin is currently 14°C with overcast skies and a 70% chance of rain today.",
+		},
+		description:
+			"ReAct interleaves Thought → Action → Observation steps. Each observation gates the next action, preventing hallucinated tool results. The agent terminates when it can answer the question from accumulated observations.",
+	},
+
+	rag: {
+		id: "rag",
+		input: {
+			query: "What is the return policy for items purchased with a gift card?",
+			retrievedChunks: [
+				{
+					id: "policy-v3-§4.2",
+					text: "Gift-card purchases are eligible for store credit only; cash refunds are not issued.",
+				},
+				{
+					id: "policy-v3-§4.5",
+					text: "All returns must be initiated within 30 days of purchase with original receipt.",
+				},
+			],
+		},
+		expectedOutput: {
+			answer:
+				"Items purchased with a gift card are eligible for store credit only — cash refunds are not issued [policy-v3-§4.2]. Returns must be initiated within 30 days of purchase with the original receipt [policy-v3-§4.5].",
+			citations: ["policy-v3-§4.2", "policy-v3-§4.5"],
+			noEvidenceHandling:
+				"If no relevant chunk is retrieved, reply: 'I could not find a policy covering this case; please contact support.'",
+		},
+		description:
+			"RAG requires the model to cite every claim with a source id. The prompt orders context as: system rules → task → retrieved evidence. If retrieval is empty the model follows a defined fallback rather than hallucinating.",
+	},
+
+	reflexion: {
+		id: "reflexion",
+		input: {
+			task: "Summarise the key contributions of the 2017 Attention Is All You Need paper in three bullet points.",
+			firstAttempt:
+				"• Transformers use multi-head attention. • They eliminated recurrent layers. • The model achieved state-of-the-art on WMT translation.",
+			rubric:
+				"Each bullet must name the contribution AND explain why it matters. Generic claims like 'state-of-the-art' without specifics score 0.",
+		},
+		expectedOutput: {
+			selfCritique:
+				"Bullet 3 is too vague — 'state-of-the-art' with no metric or comparison set. Bullet 1 doesn't explain why multi-head attention helps. Bullet 2 is the strongest.",
+			revisedAnswer: [
+				"Multi-head attention lets the model attend to different positions simultaneously, capturing richer syntactic and semantic relationships than a single attention head.",
+				"Removing recurrent layers enables full parallelisation over sequence positions, cutting training time dramatically on TPUs and GPUs.",
+				"The Transformer achieved 28.4 BLEU on WMT En→De, outperforming all prior ensembles while using fewer FLOPs than recurrent architectures.",
+			],
+			iterationsUsed: 1,
+		},
+		description:
+			"Reflexion asks the model to score its own output against an explicit rubric, write a self-critique naming specific failure modes, then produce a revised answer. Iteration count is capped to prevent infinite loops.",
+	},
+
+	"tree-of-thoughts": {
+		id: "tree-of-thoughts",
+		input: {
+			task: "Plan a 3-day city trip to Lisbon on a tight budget. Produce two candidate itinerary openings, score each, and continue with the better one.",
+			evaluationCriterion:
+				"Score 1–5 on: cost efficiency, cultural coverage, travel-time minimisation.",
+		},
+		expectedOutput: {
+			candidates: [
+				{
+					thought:
+						"Day 1 morning: free viewpoints (Miradouro da Graça) + Alfama walk.",
+					score: {
+						costEfficiency: 5,
+						culturalCoverage: 4,
+						travelTime: 4,
+						total: 13,
+					},
+				},
+				{
+					thought:
+						"Day 1 morning: Belém Tower + Jerónimos Monastery (entrance fees ~€20).",
+					score: {
+						costEfficiency: 2,
+						culturalCoverage: 5,
+						travelTime: 2,
+						total: 9,
+					},
+				},
+			],
+			selected: "candidates[0]",
+			rationale:
+				"Higher total score; entrance fees avoided on day 1 leave budget for day 2 museums.",
+			continuation:
+				"Day 1 afternoon: LX Factory market (free entry, local craft food); evening: petiscos in Mouraria.",
+		},
+		description:
+			"Tree of Thoughts generates multiple candidate thoughts at each step, scores them against an explicit criterion, prunes low-scoring branches, and backtracks if the chosen path dead-ends. Depth is bounded by the iteration limit.",
+	},
+
+	pal: {
+		id: "pal",
+		input: {
+			task: "A store sells apples at €0.40 each and bananas at €0.25 each. Alice buys 7 apples and 13 bananas. What is her total bill?",
+		},
+		expectedOutput: {
+			code: [
+				"# PAL: delegate arithmetic to the interpreter",
+				"apple_price = 0.40",
+				"banana_price = 0.25",
+				"apples_bought = 7",
+				"bananas_bought = 13",
+				"# Mathematical intent: sum of unit-price × quantity for each item",
+				"total = (apple_price * apples_bought) + (banana_price * bananas_bought)",
+				"print(f'Total bill: €{total:.2f}')",
+			].join("\n"),
+			executionResult: "Total bill: €6.05",
+			finalAnswer: "Alice's total bill is €6.05.",
+		},
+		description:
+			"PAL directs the model to express the solution as executable code, annotating each block with its mathematical intent. The final answer is derived from the execution result, not from natural-language arithmetic — eliminating numerical reasoning errors.",
+	},
+
+	"self-consistency": {
+		id: "self-consistency",
+		input: {
+			task: "Is the number 91 prime? Reason step by step, then answer yes or no.",
+			samplingConfig: {
+				samples: 3,
+				aggregation: "majority-vote",
+				tieBreaker: "prefer 'no'",
+			},
+		},
+		expectedOutput: {
+			samples: [
+				{
+					reasoning: "91 = 7 × 13. It has factors other than 1 and itself.",
+					answer: "no",
+				},
+				{
+					reasoning: "Check divisibility: 91 / 7 = 13 exactly. Not prime.",
+					answer: "no",
+				},
+				{
+					reasoning:
+						"Square root of 91 ≈ 9.5. Test 2,3,5,7: 91/7 = 13. Composite.",
+					answer: "no",
+				},
+			],
+			aggregation: { no: 3, yes: 0 },
+			finalAnswer: "no",
+			confidence: "unanimous (3/3)",
+		},
+		description:
+			"Self-Consistency generates multiple independent reasoning traces and aggregates by majority vote. Each sample is produced without referencing prior outputs. A tie-breaking rule handles split votes. The majority answer is the final output.",
+	},
+
+	"meta-prompting": {
+		id: "meta-prompting",
+		input: {
+			originalPrompt: "Write a report about climate change.",
+			evalCriteria:
+				"Score 1–5 on: specificity, actionability, output-format clarity.",
+			stopCondition:
+				"Keep the original prompt if the regenerated one does not score higher on the eval.",
+		},
+		expectedOutput: {
+			promptCritique:
+				"The prompt lacks scope (which aspect of climate change?), audience, required length, and output structure. It scores 1/5 on specificity and 1/5 on format clarity.",
+			revisedPrompt:
+				"You are a science communicator writing for a non-specialist audience. Produce a 400-word explainer on the three main drivers of rising global average temperatures since 1950 (greenhouse-gas emissions, deforestation, and industrial aerosols). Structure: intro (1 paragraph), one section per driver (2–3 sentences each), conclusion with one concrete individual action. Avoid jargon; define any technical term on first use.",
+			evalScores: {
+				original: {
+					specificity: 1,
+					actionability: 2,
+					formatClarity: 1,
+					total: 4,
+				},
+				revised: {
+					specificity: 5,
+					actionability: 4,
+					formatClarity: 5,
+					total: 14,
+				},
+			},
+			decision:
+				"revised (14 > 4); original would be kept only if revised scored ≤ original.",
+		},
+		description:
+			"Meta-Prompting separates the prompt-critique step from the task-execution step. The model evaluates the original prompt against explicit criteria, rewrites it, and scores both versions. The stop condition — keep the original if the revision does not beat it — prevents regressive rewrites.",
+	},
+};
+
+/** Look up a worked-example card by technique id. Returns undefined for catalog-only techniques. */
+export function getTechniqueCard(id: string): TechniqueCard | undefined {
+	return TECHNIQUE_CARDS[id];
+}

--- a/src/skills/prompt/technique-selector.ts
+++ b/src/skills/prompt/technique-selector.ts
@@ -1,0 +1,80 @@
+import type { InstructionInput } from "../../contracts/runtime.js";
+import { extractRequestSignals } from "../shared/recommendations.js";
+import {
+	getTechnique,
+	TECHNIQUE_CATALOG,
+	type TechniqueCategory,
+	type TechniqueEntry,
+} from "./technique-catalog.js";
+
+export interface TechniqueSelection {
+	category: TechniqueCategory | "unclassified";
+	primary: string | null;
+	supplementary: string[];
+	structureRequirements: string[];
+	rationale: string;
+	confident: boolean;
+}
+
+/** Stable keyword scorer over the catalog (mirrors rankCandidateTools). */
+function scoreTechniques(
+	request: string,
+): { entry: TechniqueEntry; score: number }[] {
+	const lower = request.toLowerCase();
+	return TECHNIQUE_CATALOG.map((entry, index) => ({
+		entry,
+		index,
+		score: entry.keywords.filter((kw) => lower.includes(kw)).length,
+	}))
+		.sort((a, b) => b.score - a.score || a.index - b.index)
+		.map(({ entry, score }) => ({ entry, score }));
+}
+
+export function selectTechniques(input: InstructionInput): TechniqueSelection {
+	const signals = extractRequestSignals(input);
+	const combined = `${input.request ?? ""} ${input.context ?? ""}`;
+	const ranked = scoreTechniques(combined);
+	const top = ranked[0];
+
+	if (!top || top.score === 0 || signals.keywords.length === 0) {
+		return {
+			category: "unclassified",
+			primary: null,
+			supplementary: [],
+			structureRequirements: [],
+			rationale:
+				"No technique keyword matched the request; defaulting to unclassified. Provide the task's reasoning/retrieval/tool-use shape to select a technique.",
+			confident: false,
+		};
+	}
+
+	const primary = top.entry;
+	const supplementary = ranked
+		.slice(1)
+		.filter((r) => r.score > 0 && r.entry.category === primary.category)
+		.slice(0, 2)
+		.map((r) => r.entry.id);
+
+	const escalation = primary.escalatesTo
+		.map((id) => getTechnique(id)?.name)
+		.filter((n): n is string => Boolean(n));
+
+	const rationale = [
+		`Classified as ${primary.category}: strongest keyword match is ${primary.name} (${top.score} signal${top.score === 1 ? "" : "s"}).`,
+		supplementary.length ? `Supplementary: ${supplementary.join(", ")}.` : "",
+		escalation.length
+			? `Consider escalating to ${escalation.join(" or ")} if the primary technique underperforms.`
+			: "",
+	]
+		.filter(Boolean)
+		.join(" ");
+
+	return {
+		category: primary.category,
+		primary: primary.id,
+		supplementary,
+		structureRequirements: [...primary.structureSignals],
+		rationale,
+		confident: true,
+	};
+}

--- a/src/skills/prompt/technique-selector.ts
+++ b/src/skills/prompt/technique-selector.ts
@@ -1,5 +1,4 @@
 import type { InstructionInput } from "../../contracts/runtime.js";
-import { extractRequestSignals } from "../shared/recommendations.js";
 import {
 	getTechnique,
 	TECHNIQUE_CATALOG,
@@ -33,12 +32,14 @@ function scoreTechniques(
 }
 
 export function selectTechniques(input: InstructionInput): TechniqueSelection {
-	const signals = extractRequestSignals(input);
 	const combined = `${input.request ?? ""} ${input.context ?? ""}`;
 	const ranked = scoreTechniques(combined);
 	const top = ranked[0];
 
-	if (!top || top.score === 0 || signals.keywords.length === 0) {
+	// Gate solely on whether any technique keyword matched. (Previously this also
+	// checked `extractRequestSignals().keywords.length`, but that could suppress a
+	// valid selection on a short input whose only signal is a technique keyword.)
+	if (!top || top.score === 0) {
 		return {
 			category: "unclassified",
 			primary: null,

--- a/src/skills/prompt/technique-selector.ts
+++ b/src/skills/prompt/technique-selector.ts
@@ -14,6 +14,8 @@ export interface TechniqueSelection {
 	structureRequirements: string[];
 	rationale: string;
 	confident: boolean;
+	/** Pointer to a worked card in technique-examples.ts; null for catalog-only or unclassified. */
+	exampleRef: string | null;
 }
 
 /** Stable keyword scorer over the catalog (mirrors rankCandidateTools). */
@@ -45,6 +47,7 @@ export function selectTechniques(input: InstructionInput): TechniqueSelection {
 			rationale:
 				"No technique keyword matched the request; defaulting to unclassified. Provide the task's reasoning/retrieval/tool-use shape to select a technique.",
 			confident: false,
+			exampleRef: null,
 		};
 	}
 
@@ -76,5 +79,6 @@ export function selectTechniques(input: InstructionInput): TechniqueSelection {
 		structureRequirements: [...primary.structureSignals],
 		rationale,
 		confident: true,
+		exampleRef: primary.exampleRef ?? null,
 	};
 }

--- a/src/skills/shared/workspace-grounding.ts
+++ b/src/skills/shared/workspace-grounding.ts
@@ -1,6 +1,7 @@
 import type {
 	InstructionEvidenceItem,
 	InstructionInput,
+	RecommendationItem,
 } from "../../contracts/runtime.js";
 import type { SkillExecutionContext } from "../runtime/contracts.js";
 import { extractReferencedPaths } from "./recommendations.js";
@@ -107,4 +108,110 @@ export function buildWorkspaceEvidence(
 		excerpt: file.excerpt,
 		authority: "implementation" as const,
 	}));
+}
+
+// ─── Symbol grounding (Serena-backed) ────────────────────────────────────────
+
+const MAX_SYMBOLS = 3;
+
+/**
+ * Extract CamelCase / PascalCase identifiers from the request text that are
+ * plausible symbol seeds (length ≥ 4, contain at least one uppercase letter
+ * not at position 0 only).  Returns up to `limit` unique names in stable order.
+ */
+function extractSymbolSeeds(request: string, limit: number): string[] {
+	// Match PascalCase / camelCase identifiers (≥ 4 chars, mixed-case)
+	const matches = request.match(/\b[A-Za-z][a-z]+(?:[A-Z][a-z]*)+\w*\b/g) ?? [];
+	const seen = new Set<string>();
+	const seeds: string[] = [];
+	for (const m of matches) {
+		if (!seen.has(m)) {
+			seen.add(m);
+			seeds.push(m);
+			if (seeds.length >= limit) break;
+		}
+	}
+	return seeds;
+}
+
+/**
+ * Query Serena for symbols / definitions that the request names but the caller
+ * may not have fully resolved.  Returns `RecommendationItem[]` with
+ * `groundingScope: "workspace"` and symbol refs in `evidenceAnchors`.
+ *
+ * Safety contract:
+ * - Returns `[]` when `context.runtime.serena` is undefined (graceful degrade).
+ * - Caps results at `opts.maxSymbols` (default 3).
+ * - NEVER throws: all Serena interaction is wrapped in try/catch; partial
+ *   results collected before an error are returned as-is.
+ */
+export async function resolveSymbolGrounding(
+	context: SkillExecutionContext,
+	opts?: { maxSymbols?: number },
+): Promise<RecommendationItem[]> {
+	const serena = context.runtime.serena;
+	if (!serena) {
+		return [];
+	}
+
+	const cap = opts?.maxSymbols ?? MAX_SYMBOLS;
+	const seeds = extractSymbolSeeds(context.input.request, cap);
+	// If no CamelCase identifiers are found, issue a single overview query as a
+	// best-effort seed so advisory results can still surface Serena guidance.
+	const queriesToRun =
+		seeds.length > 0
+			? seeds.slice(0, cap)
+			: (["find_symbol_fallback"] as const);
+
+	const items: RecommendationItem[] = [];
+
+	try {
+		for (const seed of queriesToRun) {
+			if (items.length >= cap) break;
+			try {
+				const query =
+					seed === "find_symbol_fallback"
+						? ({
+								kind: "find_symbol",
+								namePath: context.input.request.split(/\s+/)[0] ?? "unknown",
+							} as const)
+						: ({ kind: "find_symbol", namePath: seed } as const);
+
+				const result = await serena.query(query);
+
+				if (result.kind === "data") {
+					// Real resolved symbol data: cite the symbol as an evidence anchor.
+					const data = result.data as Record<string, unknown>;
+					const symbolName = typeof data.name === "string" ? data.name : seed;
+					const symbolPath =
+						typeof data.relativePath === "string"
+							? data.relativePath
+							: result.tool;
+					items.push({
+						title: `Symbol reference: ${symbolName}`,
+						detail: `Serena resolved "${symbolName}" in ${symbolPath}. Review this definition and its call-sites to ground the analysis in the actual codebase.`,
+						modelClass: context.model.modelClass,
+						groundingScope: "workspace",
+						evidenceAnchors: [symbolPath],
+					});
+				} else if (result.kind === "advisory") {
+					// Advisory: emit the Serena hint as a finding so the host can act.
+					items.push({
+						title: `Serena symbol advisory: ${seed === "find_symbol_fallback" ? "find_symbol" : seed}`,
+						detail: result.rationale,
+						modelClass: context.model.modelClass,
+						groundingScope: "workspace",
+						evidenceAnchors: [result.suggestedTool],
+					});
+				}
+				// error variant: contribute nothing for this seed (safe degrade)
+			} catch {
+				// per-seed error — skip and continue collecting
+			}
+		}
+	} catch {
+		// outer guard — return whatever was collected before the unexpected throw
+	}
+
+	return items;
 }

--- a/src/skills/shared/workspace-grounding.ts
+++ b/src/skills/shared/workspace-grounding.ts
@@ -115,6 +115,32 @@ export function buildWorkspaceEvidence(
 const MAX_SYMBOLS = 3;
 
 /**
+ * Stopword set for filtering implausible symbol fallback seeds.
+ * These are common English words/question words that should not trigger
+ * a Serena query when no CamelCase identifiers are found in the request.
+ */
+const FALLBACK_STOPWORDS = new Set([
+	"why",
+	"how",
+	"what",
+	"when",
+	"where",
+	"which",
+	"that",
+	"this",
+	"the",
+	"and",
+	"for",
+	"with",
+	"from",
+	"into",
+	"does",
+	"should",
+	"could",
+	"would",
+]);
+
+/**
  * Extract CamelCase / PascalCase identifiers from the request text that are
  * plausible symbol seeds (length ≥ 4, contain at least one uppercase letter
  * not at position 0 only).  Returns up to `limit` unique names in stable order.
@@ -132,6 +158,17 @@ function extractSymbolSeeds(request: string, limit: number): string[] {
 		}
 	}
 	return seeds;
+}
+
+/**
+ * Check if a token is a plausible symbol seed for fallback queries.
+ * A token is plausible if its length ≥ 4 AND it is not a stopword.
+ */
+function isPlausibleSymbolSeed(token: string): boolean {
+	if (token.length < 4) {
+		return false;
+	}
+	return !FALLBACK_STOPWORDS.has(token.toLowerCase());
 }
 
 /**
@@ -156,12 +193,19 @@ export async function resolveSymbolGrounding(
 
 	const cap = opts?.maxSymbols ?? MAX_SYMBOLS;
 	const seeds = extractSymbolSeeds(context.input.request, cap);
-	// If no CamelCase identifiers are found, issue a single overview query as a
-	// best-effort seed so advisory results can still surface Serena guidance.
-	const queriesToRun =
-		seeds.length > 0
-			? seeds.slice(0, cap)
-			: (["find_symbol_fallback"] as const);
+	// If no CamelCase identifiers are found, check if the first token is a
+	// plausible symbol seed before issuing a fallback query. Skip if it's a
+	// stopword or too short to reduce wasted round-trips.
+	let queriesToRun: readonly (string | "find_symbol_fallback")[] = [];
+	if (seeds.length > 0) {
+		queriesToRun = seeds.slice(0, cap);
+	} else {
+		const firstToken = context.input.request.split(/\s+/)[0];
+		if (firstToken && isPlausibleSymbolSeed(firstToken)) {
+			queriesToRun = ["find_symbol_fallback"] as const;
+		}
+		// else: no CamelCase seeds + first token not plausible → skip fallback entirely
+	}
 
 	const items: RecommendationItem[] = [];
 

--- a/src/skills/shared/workspace-grounding.ts
+++ b/src/skills/shared/workspace-grounding.ts
@@ -193,59 +193,68 @@ export async function resolveSymbolGrounding(
 
 	const cap = opts?.maxSymbols ?? MAX_SYMBOLS;
 	const seeds = extractSymbolSeeds(context.input.request, cap);
-	// If no CamelCase identifiers are found, check if the first token is a
-	// plausible symbol seed before issuing a fallback query. Skip if it's a
-	// stopword or too short to reduce wasted round-trips.
-	let queriesToRun: readonly (string | "find_symbol_fallback")[] = [];
+	// Build the concrete symbol seeds to query. Prefer CamelCase identifiers
+	// named in the request; if none are present, fall back to the first token
+	// only when it is a plausible symbol seed (skips stopwords / short tokens).
+	let seedQueries: string[];
 	if (seeds.length > 0) {
-		queriesToRun = seeds.slice(0, cap);
+		seedQueries = seeds.slice(0, cap);
 	} else {
 		const firstToken = context.input.request.split(/\s+/)[0];
-		if (firstToken && isPlausibleSymbolSeed(firstToken)) {
-			queriesToRun = ["find_symbol_fallback"] as const;
-		}
-		// else: no CamelCase seeds + first token not plausible → skip fallback entirely
+		seedQueries =
+			firstToken && isPlausibleSymbolSeed(firstToken) ? [firstToken] : [];
 	}
 
 	const items: RecommendationItem[] = [];
 
 	try {
-		for (const seed of queriesToRun) {
+		for (const seed of seedQueries) {
 			if (items.length >= cap) break;
 			try {
-				const query =
-					seed === "find_symbol_fallback"
-						? ({
-								kind: "find_symbol",
-								namePath: context.input.request.split(/\s+/)[0] ?? "unknown",
-							} as const)
-						: ({ kind: "find_symbol", namePath: seed } as const);
-
-				const result = await serena.query(query);
+				const result = await serena.query({
+					kind: "find_symbol",
+					namePath: seed,
+				});
 
 				if (result.kind === "data") {
-					// Real resolved symbol data: cite the symbol as an evidence anchor.
+					// Real resolved symbol data. Only a genuine file path is a
+					// workspace artifact worth an evidence anchor; when Serena
+					// returns a raw payload without `relativePath` (e.g. the child
+					// client's `{ content: [...] }`), degrade to a tool hint under
+					// `sourceRefs` rather than fabricating a path.
 					const data = result.data as Record<string, unknown>;
 					const symbolName = typeof data.name === "string" ? data.name : seed;
 					const symbolPath =
 						typeof data.relativePath === "string"
 							? data.relativePath
-							: result.tool;
-					items.push({
-						title: `Symbol reference: ${symbolName}`,
-						detail: `Serena resolved "${symbolName}" in ${symbolPath}. Review this definition and its call-sites to ground the analysis in the actual codebase.`,
-						modelClass: context.model.modelClass,
-						groundingScope: "workspace",
-						evidenceAnchors: [symbolPath],
-					});
+							: undefined;
+					items.push(
+						symbolPath
+							? {
+									title: `Symbol reference: ${symbolName}`,
+									detail: `Serena resolved "${symbolName}" in ${symbolPath}. Review this definition and its call-sites to ground the analysis in the actual codebase.`,
+									modelClass: context.model.modelClass,
+									groundingScope: "workspace",
+									evidenceAnchors: [symbolPath],
+								}
+							: {
+									title: `Symbol reference: ${symbolName}`,
+									detail: `Serena resolved "${symbolName}" — inspect via ${result.tool} to locate the definition and its call-sites.`,
+									modelClass: context.model.modelClass,
+									groundingScope: "workspace",
+									sourceRefs: [result.tool],
+								},
+					);
 				} else if (result.kind === "advisory") {
-					// Advisory: emit the Serena hint as a finding so the host can act.
+					// Advisory: emit the Serena hint as a finding. The suggested tool
+					// is an action reference (sourceRefs), not a workspace artifact,
+					// so it must not populate evidenceAnchors.
 					items.push({
-						title: `Serena symbol advisory: ${seed === "find_symbol_fallback" ? "find_symbol" : seed}`,
+						title: `Serena symbol advisory: ${seed}`,
 						detail: result.rationale,
 						modelClass: context.model.modelClass,
 						groundingScope: "workspace",
-						evidenceAnchors: [result.suggestedTool],
+						sourceRefs: [result.suggestedTool],
 					});
 				}
 				// error variant: contribute nothing for this seed (safe degrade)

--- a/src/skills/skill-registry.ts
+++ b/src/skills/skill-registry.ts
@@ -86,6 +86,7 @@ export class SkillRegistry {
 			modelRouter: runtime.modelRouter,
 			resolveSkillHandler: this.resolver.resolve.bind(this.resolver),
 			workspace: this.workspace,
+			...(runtime.serena === undefined ? {} : { serena: runtime.serena }),
 		};
 
 		return skill.run(input, skillRuntime);

--- a/src/tests/instructions/instruction-registry.test.ts
+++ b/src/tests/instructions/instruction-registry.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { InstructionRegistry } from "../../instructions/instruction-registry.js";
+import { getInstructionSpec } from "../../instructions/instruction-specs.js";
+
+// Regression lock for issue #1445 (auto/black-box mode invariants).
+// These tests characterise already-shipped behaviour and must PASS immediately.
+// If any assertion fails, an invariant has regressed — do NOT weaken the test.
+describe("issue-1445 regression: meta-routing reactivationPolicy", () => {
+	it("meta-routing spec has reactivationPolicy === 'session-start'", () => {
+		const spec = getInstructionSpec("meta-routing");
+		expect(spec).toBeDefined();
+		expect(spec?.reactivationPolicy).toBe("session-start");
+	});
+
+	it("meta-routing is on the 'discovery' surface", () => {
+		const spec = getInstructionSpec("meta-routing");
+		expect(spec?.surface).toBe("discovery");
+	});
+
+	it("meta-routing is public", () => {
+		const spec = getInstructionSpec("meta-routing");
+		expect(spec?.public).toBe(true);
+	});
+});
 
 describe("instruction-registry", () => {
 	it("indexes generated instructions by id and tool name", () => {

--- a/src/tests/runtime/serena-wiring.test.ts
+++ b/src/tests/runtime/serena-wiring.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Integration test — serena injection into the production dispatch path.
+ *
+ * Regression for #1601: serena was resolved AFTER createIntegratedRuntime(),
+ * so the baseRuntime passed to IntegratedSkillRuntime had no serena field.
+ * buildSkillRuntime() spreads base, meaning every skill execution arrived with
+ * runtime.serena === undefined regardless of the resolved client.
+ *
+ * This test drives debug-root-cause through createRuntime() → integratedRuntime
+ * → executeSkill() — the same wiring as production — and asserts that a DATA
+ * serena response produces a "Symbol reference" recommendation in the output.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createRuntime } from "../../index.js";
+import type { SerenaClient, SerenaResult } from "../../serena/client.js";
+
+function makeDataSerena(): SerenaClient {
+	return {
+		async query(): Promise<SerenaResult> {
+			return {
+				kind: "data",
+				tool: "find_symbol",
+				data: {
+					name: "SkillExecutionRuntime",
+					relativePath: "src/contracts/runtime.ts",
+					kind: "interface",
+				},
+			};
+		},
+		async close(): Promise<void> {
+			// no-op
+		},
+	};
+}
+
+describe("serena wiring — production dispatch path (#1601)", () => {
+	it("threads serena into integratedRuntime so skills receive a Serena symbol recommendation", async () => {
+		const mockSerena = makeDataSerena();
+		const runtime = createRuntime({ serena: mockSerena });
+
+		// Sanity: the outer ServerRuntime still exposes serena.
+		expect(runtime.serena).toBe(mockSerena);
+
+		// Drive debug-root-cause through the real integratedRuntime dispatch path.
+		// The request contains "SkillExecutionRuntime" (CamelCase) so resolveSymbolGrounding
+		// will call serena.query() and emit a "Symbol reference" recommendation when
+		// serena is properly wired into the baseRuntime.
+		const { result } = await runtime.integratedRuntime!.executeSkill(
+			"debug-root-cause",
+			{
+				request:
+					"investigate crash in SkillExecutionRuntime when timeout config is changed",
+			},
+			{ forceDirectExecution: true },
+		);
+
+		const serenaRecs = result.recommendations.filter(
+			(r) =>
+				r.groundingScope === "workspace" &&
+				r.title.startsWith("Symbol reference"),
+		);
+
+		expect(serenaRecs.length).toBeGreaterThan(0);
+		expect(serenaRecs[0].evidenceAnchors).toContain("src/contracts/runtime.ts");
+	});
+});

--- a/src/tests/skills/debug/debug-root-cause-grounding.test.ts
+++ b/src/tests/skills/debug/debug-root-cause-grounding.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { WorkspaceReader } from "../../../contracts/runtime.js";
+import type { SerenaClient, SerenaResult } from "../../../serena/client.js";
 import { skillModule } from "../../../skills/debug/debug-root-cause.js";
 import { createMockSkillRuntime } from "../test-helpers.js";
 
@@ -64,5 +65,71 @@ describe("debug-root-cause workspace grounding", () => {
 			result.recommendations.every((r) => r.groundingScope !== "workspace"),
 		).toBe(true);
 		expect(result.recommendations.length).toBeGreaterThan(0);
+	});
+});
+
+describe("debug-root-cause Serena symbol grounding", () => {
+	it("appends Serena symbol items when serena returns DATA for a named symbol", async () => {
+		const dataSerena: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				return {
+					kind: "data",
+					tool: "find_symbol",
+					data: {
+						name: "SkillExecutionRuntime",
+						relativePath: "src/contracts/runtime.ts",
+					},
+				};
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		const result = await skillModule.run(
+			{
+				request:
+					"investigate crash in SkillExecutionRuntime when timeout config is changed",
+			},
+			createMockSkillRuntime({ serena: dataSerena }),
+		);
+		const serenaRecs = result.recommendations.filter(
+			(r) =>
+				r.groundingScope === "workspace" &&
+				r.title.startsWith("Symbol reference"),
+		);
+		expect(serenaRecs.length).toBeGreaterThan(0);
+		expect(serenaRecs[0].evidenceAnchors).toContain("src/contracts/runtime.ts");
+	});
+
+	it("degrades gracefully and still produces recommendations when serena is absent", async () => {
+		const result = await skillModule.run(
+			{ request: "timeout after config change in the scheduler" },
+			createMockSkillRuntime({}),
+		);
+		expect(result.recommendations.length).toBeGreaterThan(0);
+		// No workspace-scoped items from Serena (serena is absent)
+		const serenaRecs = result.recommendations.filter(
+			(r) =>
+				r.title.startsWith("Symbol reference") ||
+				r.title.startsWith("Serena symbol advisory"),
+		);
+		expect(serenaRecs.length).toBe(0);
+	});
+
+	it("never throws when serena query throws", async () => {
+		const throwingSerena: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				throw new Error("Serena not available");
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		await expect(
+			skillModule.run(
+				{ request: "crash in SkillExecutionRuntime handler" },
+				createMockSkillRuntime({ serena: throwingSerena }),
+			),
+		).resolves.toBeDefined();
 	});
 });

--- a/src/tests/skills/prompt/prompt-engineering-baseline.test.ts
+++ b/src/tests/skills/prompt/prompt-engineering-baseline.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { skillModule } from "../../../skills/prompt/prompt-engineering.js";
+import { createMockSkillRuntime } from "../test-helpers.js";
+
+describe("prompt-engineering baseline (pre-selector)", () => {
+	it("emits the current artifact-kind order for a plain request", async () => {
+		const result = await skillModule.run(
+			{ request: "Write a summarization prompt" },
+			createMockSkillRuntime(),
+		);
+		expect(result.artifacts?.map((a) => a.kind)).toEqual([
+			"comparison-matrix",
+			"output-template",
+			"worked-example",
+			"tool-chain",
+		]);
+	});
+});

--- a/src/tests/skills/prompt/prompt-engineering.test.ts
+++ b/src/tests/skills/prompt/prompt-engineering.test.ts
@@ -93,6 +93,29 @@ describe("prompt-engineering", () => {
 		});
 	});
 
+	it("lists same-category supplementary techniques in the selection matrix", async () => {
+		// "sample … majority … vote" → self-consistency (primary); "reason step by
+		// step" → cot (supplementary, same reasoning category).
+		const result = await expectSkillGuidance(
+			skillModule,
+			{
+				request:
+					"reason step by step, then sample multiple answers and take the majority vote",
+			},
+			{ detailIncludes: ["Selected technique"] },
+		);
+		const matrix = result.artifacts?.find(
+			(a) =>
+				a.kind === "comparison-matrix" && a.title === "Technique selection",
+		);
+		expect(matrix).toBeDefined();
+		const supplementaryRows =
+			matrix?.kind === "comparison-matrix"
+				? matrix.rows.filter((row) => row.label === "supplementary")
+				: [];
+		expect(supplementaryRows.length).toBeGreaterThanOrEqual(1);
+	});
+
 	it("returns structured guidance for an empty request", async () => {
 		await expectEmptyRequestHandling(skillModule);
 	});

--- a/src/tests/skills/prompt/prompt-engineering.test.ts
+++ b/src/tests/skills/prompt/prompt-engineering.test.ts
@@ -67,6 +67,32 @@ describe("prompt-engineering", () => {
 		).toBe(true);
 	});
 
+	it("emits a worked-example artifact for a first-class (react) technique selection", async () => {
+		const result = await expectSkillGuidance(
+			skillModule,
+			{
+				request:
+					"Build a prompt for an agent that calls an API tool then observes the result before acting again",
+			},
+			{ detailIncludes: ["Selected technique"] },
+		);
+
+		const workedExamples = result.artifacts?.filter(
+			(a) => a.kind === "worked-example",
+		);
+		// At minimum the built-in prompt template example + the technique card
+		expect(workedExamples?.length).toBeGreaterThanOrEqual(2);
+
+		const techniqueCard = result.artifacts?.find(
+			(a) => a.kind === "worked-example" && a.title === "react worked example",
+		);
+		expect(techniqueCard).toBeDefined();
+		expect(techniqueCard).toMatchObject({
+			kind: "worked-example",
+			title: "react worked example",
+		});
+	});
+
 	it("returns structured guidance for an empty request", async () => {
 		await expectEmptyRequestHandling(skillModule);
 	});

--- a/src/tests/skills/prompt/prompt-engineering.test.ts
+++ b/src/tests/skills/prompt/prompt-engineering.test.ts
@@ -42,11 +42,29 @@ describe("prompt-engineering", () => {
 			"worked-example",
 			"tool-chain",
 			"eval-criteria",
+			"comparison-matrix",
 		]);
 		expect(result.artifacts?.[1]).toMatchObject({
 			kind: "output-template",
 			title: "system prompt template",
 		});
+	});
+
+	it("names a selected technique for a tool-use request", async () => {
+		const result = await expectSkillGuidance(
+			skillModule,
+			{
+				request:
+					"prompt for an agent that calls a tool then observes the result",
+			},
+			{ detailIncludes: ["Selected technique"] },
+		);
+		expect(
+			result.artifacts?.some(
+				(a) =>
+					a.kind === "comparison-matrix" && a.title === "Technique selection",
+			),
+		).toBe(true);
 	});
 
 	it("returns structured guidance for an empty request", async () => {

--- a/src/tests/skills/prompt/prompt-engineering.test.ts
+++ b/src/tests/skills/prompt/prompt-engineering.test.ts
@@ -80,8 +80,8 @@ describe("prompt-engineering", () => {
 		const workedExamples = result.artifacts?.filter(
 			(a) => a.kind === "worked-example",
 		);
-		// At minimum the built-in prompt template example + the technique card
-		expect(workedExamples?.length).toBeGreaterThanOrEqual(2);
+		// Exactly two: the built-in prompt template example + the react technique card
+		expect(workedExamples?.length).toBe(2);
 
 		const techniqueCard = result.artifacts?.find(
 			(a) => a.kind === "worked-example" && a.title === "react worked example",

--- a/src/tests/skills/prompt/technique-catalog.test.ts
+++ b/src/tests/skills/prompt/technique-catalog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	getTechnique,
 	TECHNIQUE_CATALOG,
+	techniquesByCategory,
 } from "../../../skills/prompt/technique-catalog.js";
 
 describe("technique-catalog", () => {
@@ -67,5 +68,20 @@ describe("technique-catalog", () => {
 				`${t.id} must not escalate to itself`,
 			).toBe(false);
 		}
+	});
+
+	it("techniquesByCategory returns exactly the entries of a category", () => {
+		const reasoning = techniquesByCategory("reasoning");
+		expect(reasoning.length).toBeGreaterThan(0);
+		expect(reasoning.every((t) => t.category === "reasoning")).toBe(true);
+		expect(reasoning.map((t) => t.id).sort()).toEqual(
+			TECHNIQUE_CATALOG.filter((t) => t.category === "reasoning")
+				.map((t) => t.id)
+				.sort(),
+		);
+		// a distinct category returns a disjoint, non-empty set
+		const agentic = techniquesByCategory("agentic");
+		expect(agentic.every((t) => t.category === "agentic")).toBe(true);
+		expect(agentic.some((t) => reasoning.includes(t))).toBe(false);
 	});
 });

--- a/src/tests/skills/prompt/technique-catalog.test.ts
+++ b/src/tests/skills/prompt/technique-catalog.test.ts
@@ -42,4 +42,30 @@ describe("technique-catalog", () => {
 			].sort(),
 		);
 	});
+
+	it("catalog-only tier contains exactly the expected 5 ids", () => {
+		const catalogOnlyIds = TECHNIQUE_CATALOG.filter(
+			(t) => t.tier === "catalog-only",
+		)
+			.map((t) => t.id)
+			.sort();
+		expect(catalogOnlyIds).toEqual(
+			[
+				"cot",
+				"few-shot",
+				"generate-knowledge",
+				"prompt-chaining",
+				"zero-shot",
+			].sort(),
+		);
+	});
+
+	it("no technique lists its own id in escalatesTo (no self-loops)", () => {
+		for (const t of TECHNIQUE_CATALOG) {
+			expect(
+				t.escalatesTo.includes(t.id),
+				`${t.id} must not escalate to itself`,
+			).toBe(false);
+		}
+	});
 });

--- a/src/tests/skills/prompt/technique-catalog.test.ts
+++ b/src/tests/skills/prompt/technique-catalog.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+	getTechnique,
+	TECHNIQUE_CATALOG,
+} from "../../../skills/prompt/technique-catalog.js";
+
+describe("technique-catalog", () => {
+	it("holds exactly the 12 non-deferred techniques", () => {
+		expect(TECHNIQUE_CATALOG).toHaveLength(12);
+		expect(new Set(TECHNIQUE_CATALOG.map((t) => t.id)).size).toBe(12);
+	});
+
+	it("gives every entry ≥1 keyword and 3–5 structure signals", () => {
+		for (const t of TECHNIQUE_CATALOG) {
+			expect(t.keywords.length).toBeGreaterThan(0);
+			expect(t.structureSignals.length).toBeGreaterThanOrEqual(3);
+			expect(t.structureSignals.length).toBeLessThanOrEqual(5);
+		}
+	});
+
+	it("only escalates to real technique ids (no dangling edges)", () => {
+		for (const t of TECHNIQUE_CATALOG) {
+			for (const target of t.escalatesTo) {
+				expect(getTechnique(target), `${t.id}→${target}`).toBeDefined();
+			}
+		}
+	});
+
+	it("marks exactly the 7 first-class techniques", () => {
+		const firstClass = TECHNIQUE_CATALOG.filter(
+			(t) => t.tier === "first-class",
+		).map((t) => t.id);
+		expect(firstClass.sort()).toEqual(
+			[
+				"meta-prompting",
+				"pal",
+				"rag",
+				"react",
+				"reflexion",
+				"self-consistency",
+				"tree-of-thoughts",
+			].sort(),
+		);
+	});
+});

--- a/src/tests/skills/prompt/technique-examples.test.ts
+++ b/src/tests/skills/prompt/technique-examples.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { TECHNIQUE_CATALOG } from "../../../skills/prompt/technique-catalog.js";
+import {
+	getTechniqueCard,
+	TECHNIQUE_CARDS,
+} from "../../../skills/prompt/technique-examples.js";
+
+describe("technique-examples", () => {
+	it("has a card for every first-class technique", () => {
+		const firstClass = TECHNIQUE_CATALOG.filter(
+			(t) => t.tier === "first-class",
+		).map((t) => t.id);
+		for (const id of firstClass) expect(getTechniqueCard(id), id).toBeDefined();
+		expect(Object.keys(TECHNIQUE_CARDS)).toHaveLength(firstClass.length);
+	});
+
+	it("every card carries input, expectedOutput, and description", () => {
+		for (const card of Object.values(TECHNIQUE_CARDS)) {
+			expect(card.input).toBeDefined();
+			expect(card.expectedOutput).toBeDefined();
+			expect(card.description.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/tests/skills/prompt/technique-selector.test.ts
+++ b/src/tests/skills/prompt/technique-selector.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { selectTechniques } from "../../../skills/prompt/technique-selector.js";
+
+const sel = (request: string) => selectTechniques({ request });
+
+describe("technique-selector (refutable triggers)", () => {
+	it("selects react for tool-observation agent tasks, not for plain summaries", () => {
+		expect(
+			sel("an agent that calls an API tool then observes the result").primary,
+		).toBe("react");
+		expect(sel("write a short summary of this paragraph").primary).not.toBe(
+			"react",
+		);
+	});
+
+	it("selects rag for retrieval/citation tasks, not for pure arithmetic", () => {
+		expect(
+			sel("answer from the knowledge base and cite the source document")
+				.primary,
+		).toBe("rag");
+		expect(sel("compute the factorial of 12").primary).not.toBe("rag");
+	});
+
+	it("selects pal for compute/math tasks, not for tone rewriting", () => {
+		expect(
+			sel("calculate and compute the numeric result with code").primary,
+		).toBe("pal");
+		expect(sel("make this email sound friendlier").primary).not.toBe("pal");
+	});
+
+	it("selects self-consistency when reliability via voting is asked", () => {
+		expect(
+			sel("sample multiple answers and take the majority vote for reliability")
+				.primary,
+		).toBe("self-consistency");
+	});
+
+	it("selects tree-of-thoughts for branch/backtrack exploration", () => {
+		expect(
+			sel("explore alternative branches and backtrack to search options")
+				.primary,
+		).toBe("tree-of-thoughts");
+	});
+
+	it("selects reflexion for self-critique/iterate loops", () => {
+		expect(
+			sel("reflect on the failure, self-critique, and iterate with feedback")
+				.primary,
+		).toBe("reflexion");
+	});
+
+	it("selects meta-prompting for regenerating the prompt itself", () => {
+		expect(
+			sel("critique the prompt and regenerate a refined prompt").primary,
+		).toBe("meta-prompting");
+	});
+
+	it("emits ≤2 supplementary techniques and a rationale string", () => {
+		const r = sel(
+			"an agent that calls a tool then observes and cites a document",
+		);
+		expect(r.supplementary.length).toBeLessThanOrEqual(2);
+		expect(r.rationale.length).toBeGreaterThan(0);
+	});
+
+	it("is low-confidence + unclassified when no technique keyword matches", () => {
+		const r = sel("hello");
+		expect(r.confident).toBe(false);
+		expect(r.primary).toBeNull();
+	});
+
+	it("is deterministic (same input → same output)", () => {
+		const a = sel("an agent that calls a tool then observes");
+		const b = sel("an agent that calls a tool then observes");
+		expect(a).toEqual(b);
+	});
+});

--- a/src/tests/skills/prompt/technique-selector.test.ts
+++ b/src/tests/skills/prompt/technique-selector.test.ts
@@ -84,4 +84,16 @@ describe("technique-selector (refutable triggers)", () => {
 		const b = sel("an agent that calls a tool then observes");
 		expect(a).toEqual(b);
 	});
+
+	it("rationale mentions 'escalating' when primary technique has escalatesTo targets", () => {
+		// react escalates to ["rag", "reflexion"] — a confident match should surface the escalation
+		const r = sel("an agent that calls an API tool then observes the result");
+		expect(r.primary).toBe("react");
+		expect(r.confident).toBe(true);
+		expect(r.rationale.toLowerCase()).toContain("escalating");
+	});
+
+	// NOTE: Every technique in the catalog has at least one escalatesTo target,
+	// so no contrast case (primary with empty escalatesTo) exists. This is
+	// documented here as a deliberate design decision per Stage D specification.
 });

--- a/src/tests/skills/prompt/technique-selector.test.ts
+++ b/src/tests/skills/prompt/technique-selector.test.ts
@@ -96,4 +96,21 @@ describe("technique-selector (refutable triggers)", () => {
 	// NOTE: Every technique in the catalog has at least one escalatesTo target,
 	// so no contrast case (primary with empty escalatesTo) exists. This is
 	// documented here as a deliberate design decision per Stage D specification.
+
+	it("scores keywords from the context field, not only the request", () => {
+		// The request alone carries no technique signal; the classification must
+		// come from the context text.
+		const r = selectTechniques({
+			request: "help me here",
+			context: "an agent that calls a tool then observes the result via an api",
+		});
+		expect(r.primary).toBe("react");
+		expect(r.confident).toBe(true);
+	});
+
+	it("uses a singular 'signal' in the rationale when exactly one keyword matches", () => {
+		const r = sel("retrieve it");
+		expect(r.primary).toBe("rag");
+		expect(r.rationale).toContain("(1 signal)");
+	});
 });

--- a/src/tests/skills/prompt/technique-selector.test.ts
+++ b/src/tests/skills/prompt/technique-selector.test.ts
@@ -33,6 +33,9 @@ describe("technique-selector (refutable triggers)", () => {
 			sel("sample multiple answers and take the majority vote for reliability")
 				.primary,
 		).toBe("self-consistency");
+		expect(sel("design the system architecture").primary).not.toBe(
+			"self-consistency",
+		);
 	});
 
 	it("selects tree-of-thoughts for branch/backtrack exploration", () => {
@@ -40,6 +43,9 @@ describe("technique-selector (refutable triggers)", () => {
 			sel("explore alternative branches and backtrack to search options")
 				.primary,
 		).toBe("tree-of-thoughts");
+		expect(sel("write a short poem about autumn").primary).not.toBe(
+			"tree-of-thoughts",
+		);
 	});
 
 	it("selects reflexion for self-critique/iterate loops", () => {
@@ -47,12 +53,16 @@ describe("technique-selector (refutable triggers)", () => {
 			sel("reflect on the failure, self-critique, and iterate with feedback")
 				.primary,
 		).toBe("reflexion");
+		expect(sel("calculate the sum of 1 to 100").primary).not.toBe("reflexion");
 	});
 
 	it("selects meta-prompting for regenerating the prompt itself", () => {
 		expect(
 			sel("critique the prompt and regenerate a refined prompt").primary,
 		).toBe("meta-prompting");
+		expect(sel("retrieve documents from the knowledge base").primary).not.toBe(
+			"meta-prompting",
+		);
 	});
 
 	it("emits ≤2 supplementary techniques and a rationale string", () => {

--- a/src/tests/skills/shared/serena-grounding.test.ts
+++ b/src/tests/skills/shared/serena-grounding.test.ts
@@ -163,4 +163,62 @@ describe("resolveSymbolGrounding", () => {
 		const result = await resolveSymbolGrounding(context);
 		expect(result.length).toBeLessThanOrEqual(3);
 	});
+
+	it("skips fallback when first token is a stopword or too short (no CamelCase identifiers)", async () => {
+		let queryCallCount = 0;
+		const spyingClient: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				queryCallCount++;
+				return {
+					kind: "data",
+					tool: "find_symbol",
+					data: {
+						name: "MockSymbol",
+						relativePath: "src/mock.ts",
+					},
+				};
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		// Request starts with stopword "why" and has no CamelCase identifiers
+		// → fallback should be skipped, serena.query should NOT be called
+		const context = createMockSkillExecutionContext({
+			input: { request: "why is this failing?" },
+			runtime: createMockSkillRuntime({ serena: spyingClient }),
+		});
+		const result = await resolveSymbolGrounding(context);
+		expect(result).toEqual([]);
+		expect(queryCallCount).toBe(0); // serena.query was never called
+	});
+
+	it("includes fallback when first token is plausible (length >= 4, not a stopword)", async () => {
+		let queryCallCount = 0;
+		const spyingClient: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				queryCallCount++;
+				return {
+					kind: "data",
+					tool: "find_symbol",
+					data: {
+						name: "DebugInfo",
+						relativePath: "src/debug.ts",
+					},
+				};
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		// Request starts with "debug" (length 5, not a stopword) and has no CamelCase identifiers
+		// → fallback should run, serena.query should be called once
+		const context = createMockSkillExecutionContext({
+			input: { request: "debug the timeout in the scheduler module" },
+			runtime: createMockSkillRuntime({ serena: spyingClient }),
+		});
+		const result = await resolveSymbolGrounding(context);
+		expect(result.length).toBeGreaterThan(0);
+		expect(queryCallCount).toBe(1); // serena.query was called once for the fallback
+	});
 });

--- a/src/tests/skills/shared/serena-grounding.test.ts
+++ b/src/tests/skills/shared/serena-grounding.test.ts
@@ -221,4 +221,71 @@ describe("resolveSymbolGrounding", () => {
 		expect(result.length).toBeGreaterThan(0);
 		expect(queryCallCount).toBe(1); // serena.query was called once for the fallback
 	});
+
+	it("uses sourceRefs (not evidenceAnchors) for an advisory tool hint", async () => {
+		const advisoryClient: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				return {
+					kind: "advisory",
+					suggestedTool: "mcp__serena__find_symbol",
+					suggestedArgs: {},
+					rationale: "advisory rationale",
+				};
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		const context = createMockSkillExecutionContext({
+			input: { request: "inspect ParseSkillInput usage" },
+			runtime: createMockSkillRuntime({ serena: advisoryClient }),
+		});
+		const [item] = await resolveSymbolGrounding(context);
+		// The suggested tool is an action reference, not a workspace artifact.
+		expect(item.sourceRefs).toEqual(["mcp__serena__find_symbol"]);
+		expect(item.evidenceAnchors).toBeUndefined();
+	});
+
+	it("degrades to a tool hint (no fabricated path) when DATA lacks a relativePath", async () => {
+		// ChildSerenaClient returns the raw MCP callTool result, e.g. { content: [...] }
+		// with no relativePath — we must NOT fabricate an evidence anchor from the tool.
+		const rawDataClient: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				return {
+					kind: "data",
+					tool: "find_symbol",
+					data: { content: [{ type: "text", text: "..." }] },
+				};
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		const context = createMockSkillExecutionContext({
+			input: { request: "resolve ScheduleWakeup definition" },
+			runtime: createMockSkillRuntime({ serena: rawDataClient }),
+		});
+		const [item] = await resolveSymbolGrounding(context);
+		expect(item.evidenceAnchors).toBeUndefined();
+		expect(item.sourceRefs).toEqual(["find_symbol"]);
+		// name falls back to the seed since data.name is absent
+		expect(item.title).toContain("ScheduleWakeup");
+		expect(item.detail).toContain("inspect via find_symbol");
+	});
+
+	it("contributes nothing for the error variant", async () => {
+		const errorClient: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				return { kind: "error", tool: "find_symbol", error: "not found" };
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		const context = createMockSkillExecutionContext({
+			input: { request: "resolve MissingSymbol here" },
+			runtime: createMockSkillRuntime({ serena: errorClient }),
+		});
+		expect(await resolveSymbolGrounding(context)).toEqual([]);
+	});
 });

--- a/src/tests/skills/shared/serena-grounding.test.ts
+++ b/src/tests/skills/shared/serena-grounding.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SerenaClient, SerenaResult } from "../../../serena/client.js";
+import { resolveSymbolGrounding } from "../../../skills/shared/workspace-grounding.js";
 import {
 	createMockSkillExecutionContext,
 	createMockSkillRuntime,
@@ -43,5 +44,123 @@ describe("serena grounding seam", () => {
 			namePath: "SkillExecutionRuntime",
 		});
 		expect(result?.kind).toBe("advisory");
+	});
+});
+
+// ─── resolveSymbolGrounding ───────────────────────────────────────────────────
+
+describe("resolveSymbolGrounding", () => {
+	it("returns [] when context.runtime.serena is undefined", async () => {
+		const context = createMockSkillExecutionContext({
+			runtime: createMockSkillRuntime(),
+		});
+		const result = await resolveSymbolGrounding(context);
+		expect(result).toEqual([]);
+	});
+
+	it("returns a RecommendationItem citing the symbol when serena returns DATA", async () => {
+		const dataClient: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				return {
+					kind: "data",
+					tool: "find_symbol",
+					data: {
+						name: "resolveSerenaClient",
+						relativePath: "src/serena/client.ts",
+						kind: "function",
+					},
+				};
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		const context = createMockSkillExecutionContext({
+			input: { request: "debug the timeout in the scheduler module" },
+			runtime: createMockSkillRuntime({ serena: dataClient }),
+		});
+		const result = await resolveSymbolGrounding(context);
+		expect(result.length).toBeGreaterThan(0);
+		const item = result[0];
+		expect(item.groundingScope).toBe("workspace");
+		expect(Array.isArray(item.evidenceAnchors)).toBe(true);
+		expect(item.evidenceAnchors!.length).toBeGreaterThan(0);
+		expect(item.title.length).toBeGreaterThan(0);
+		expect(item.detail.length).toBeGreaterThan(0);
+		expect(item.modelClass).toBeDefined();
+	});
+
+	it("returns a finding carrying the advisory hint when serena returns ADVISORY", async () => {
+		const advisoryClient: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				return {
+					kind: "advisory",
+					suggestedTool: "mcp__serena__find_symbol",
+					suggestedArgs: { name_path: "SkillExecutionRuntime" },
+					rationale:
+						"Resolve symbol via Serena LSP for accurate location data.",
+				};
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		const context = createMockSkillExecutionContext({
+			input: { request: "find all uses of SkillExecutionRuntime" },
+			runtime: createMockSkillRuntime({ serena: advisoryClient }),
+		});
+		const result = await resolveSymbolGrounding(context);
+		expect(result.length).toBeGreaterThan(0);
+		const item = result[0];
+		expect(item.groundingScope).toBe("workspace");
+		// Advisory items carry the rationale in detail
+		expect(item.detail).toContain("Resolve symbol via Serena LSP");
+	});
+
+	it("returns [] and never throws when the mock serena query throws", async () => {
+		const throwingClient: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				throw new Error("Serena connection refused");
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		const context = createMockSkillExecutionContext({
+			input: { request: "fix the crash in parseSkillInput" },
+			runtime: createMockSkillRuntime({ serena: throwingClient }),
+		});
+		// Must never propagate — must return []
+		await expect(resolveSymbolGrounding(context)).resolves.toEqual([]);
+	});
+
+	it("caps results at maxSymbols (default 3)", async () => {
+		let callCount = 0;
+		const multiDataClient: SerenaClient = {
+			async query(): Promise<SerenaResult> {
+				callCount++;
+				return {
+					kind: "data",
+					tool: "find_symbol",
+					data: {
+						name: `symbol${callCount}`,
+						relativePath: `src/x${callCount}.ts`,
+					},
+				};
+			},
+			async close(): Promise<void> {
+				// no-op
+			},
+		};
+		// Request with 5 CamelCase identifiers → seed extraction may find multiple
+		const context = createMockSkillExecutionContext({
+			input: {
+				request:
+					"investigate SkillHandler SkillModule SkillExecutionContext SkillResolver SkillRegistry",
+			},
+			runtime: createMockSkillRuntime({ serena: multiDataClient }),
+		});
+		const result = await resolveSymbolGrounding(context);
+		expect(result.length).toBeLessThanOrEqual(3);
 	});
 });

--- a/src/tests/skills/shared/serena-grounding.test.ts
+++ b/src/tests/skills/shared/serena-grounding.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { SerenaClient, SerenaResult } from "../../../serena/client.js";
+import {
+	createMockSkillExecutionContext,
+	createMockSkillRuntime,
+} from "../test-helpers.js";
+
+function mockSerenaClient(): SerenaClient {
+	return {
+		async query(): Promise<SerenaResult> {
+			return {
+				kind: "advisory",
+				suggestedTool: "mcp__serena__find_symbol",
+				suggestedArgs: { name_path: "SkillExecutionRuntime" },
+				rationale: "mock advisory",
+			};
+		},
+		async close(): Promise<void> {
+			// no-op
+		},
+	};
+}
+
+describe("serena grounding seam", () => {
+	it("createMockSkillRuntime propagates serena when provided", () => {
+		const serena = mockSerenaClient();
+		const runtime = createMockSkillRuntime({ serena });
+		expect(runtime.serena).toBe(serena);
+	});
+
+	it("createMockSkillRuntime leaves serena undefined when not provided", () => {
+		const runtime = createMockSkillRuntime();
+		expect(runtime.serena).toBeUndefined();
+	});
+
+	it("skill handler can read context.runtime.serena", async () => {
+		const serena = mockSerenaClient();
+		const context = createMockSkillExecutionContext({
+			runtime: createMockSkillRuntime({ serena }),
+		});
+		const result = await context.runtime.serena?.query({
+			kind: "find_symbol",
+			namePath: "SkillExecutionRuntime",
+		});
+		expect(result?.kind).toBe("advisory");
+	});
+});

--- a/src/tests/skills/test-helpers.ts
+++ b/src/tests/skills/test-helpers.ts
@@ -9,6 +9,7 @@ import type {
 	WorkflowExecutionRuntime,
 	WorkspaceReader,
 } from "../../contracts/runtime.js";
+import type { SerenaClient } from "../../serena/client.js";
 import type { SkillExecutionContext } from "../../skills/runtime/contracts.js";
 
 export const mockModelProfile: ModelProfile = {
@@ -71,6 +72,23 @@ export function createMockSkillRuntime(
 		...(overrides.workspace === undefined
 			? {}
 			: { workspace: overrides.workspace }),
+		...(overrides.serena === undefined ? {} : { serena: overrides.serena }),
+	};
+}
+
+export function createMockSerenaClient(): SerenaClient {
+	return {
+		async query() {
+			return {
+				kind: "advisory" as const,
+				suggestedTool: "mcp__serena__find_symbol",
+				suggestedArgs: {},
+				rationale: "mock serena advisory",
+			};
+		},
+		async close() {
+			// no-op
+		},
 	};
 }
 

--- a/src/tests/skills/test-helpers.ts
+++ b/src/tests/skills/test-helpers.ts
@@ -9,7 +9,6 @@ import type {
 	WorkflowExecutionRuntime,
 	WorkspaceReader,
 } from "../../contracts/runtime.js";
-import type { SerenaClient } from "../../serena/client.js";
 import type { SkillExecutionContext } from "../../skills/runtime/contracts.js";
 
 export const mockModelProfile: ModelProfile = {
@@ -73,22 +72,6 @@ export function createMockSkillRuntime(
 			? {}
 			: { workspace: overrides.workspace }),
 		...(overrides.serena === undefined ? {} : { serena: overrides.serena }),
-	};
-}
-
-export function createMockSerenaClient(): SerenaClient {
-	return {
-		async query() {
-			return {
-				kind: "advisory" as const,
-				suggestedTool: "mcp__serena__find_symbol",
-				suggestedArgs: {},
-				rationale: "mock serena advisory",
-			};
-		},
-		async close() {
-			// no-op
-		},
 	};
 }
 


### PR DESCRIPTION
## 📝 Pull Request

### 📋 Summary

Delivers three linked issues in one branch, as separable commit stages:

- **#1605 (Phases 1–5)** — Adopts universal-creator's prompt-technique catalog + a **deterministic** selector into the `prompt-engineering` pipeline. New typed catalog (12 techniques, 3 tiers, MIT-ported), a keyword/signal selector (no sampler, per ADR 0001), 7 first-class worked cards, escalation graph in catalog data, and docs. **No new public MCP tools** — the existing prompt skills are enriched.
- **#1601** — The "strong version" of workspace grounding: `SerenaClient` is threaded into `SkillExecutionRuntime` and a bounded, never-throws `resolveSymbolGrounding()` surfaces symbols/refs the request did **not** name, wired into `debug-root-cause`.
- **#1445** — Verify + audit + harden of the already-shipped auto-mode surface: regression tests locking the shipped invariants (session-start meta-routing, routing-adapt opt-out, slim surface, hooks) + explicit anti-pattern clauses added to 9 workflow-tool descriptions.

### 🔗 Related Issues

- Part of #1605 (Phases 1–5 of the 7-phase epic; Phases 6–7 deferred with documented infra prerequisites)
- Closes #1601
- Part of #1445 (found ~90% already shipped; this adds verification tests + the item-5 description audit)

### 🏷️ PR Type & Size

**Type:** ✨ New feature (non-breaking) — additive throughout.
**Size:** 🔴 Large (multi-issue).

### 📦 Changes Made

#### Key Changes

1. **Technique catalog + selector (#1605):** `src/skills/prompt/technique-catalog.ts` (12 entries, MIT attribution), `technique-selector.ts` (deterministic; primary + ≤2 supplementary + structural requirements + rationale), `technique-examples.ts` (7 worked cards), wired into `prompt-engineering.ts`. Escalation edges live in catalog data + selector rationale only (not the generated graph — documented explicitly).
2. **Serena symbol grounding (#1601):** `serena?` added to `SkillExecutionRuntime`; threaded through the integrated-runtime dispatch path (`src/index.ts`); `resolveSymbolGrounding()` in `workspace-grounding.ts` (bounded cap, never-throws, returns `[]` when serena absent, guards stopword seeds); wired into `debug-root-cause`.
3. **Auto-mode verify/audit (#1445):** regression tests in `instruction-registry.test.ts`; anti-pattern clauses appended to 9 descriptions in `instruction-specs.ts` with regenerated `src/generated/**`.

### 🧪 Testing

- Deterministic selector has a **refutable trigger per adopted technique** (an input that selects it and one that does not).
- Serena grounding proven never-throws + `[]`-safe when serena is absent, with an **integration test through the production dispatch path** (`createRuntime({serena}).integratedRuntime.executeSkill(...)`).
- 1445 invariants locked by regression tests.

#### Testing Steps

1. `npm run build`
2. `npm test` → 2641 passed / 3 skipped
3. `npm run check:generated` → clean (no codegen drift)
4. `npm run quality` → green
5. Dogfood: invoke `prompt-engineering` with a ReAct-flavored request → names `react` + structural requirements deterministically; a retrieval request → `rag`; a plain request → no specialized technique.

### ✅ Quality Checklist

- [x] ✅ `npm run quality` passes
- [x] ✅ `npm test` passes (2641 passed / 3 skipped)
- [x] ✅ `npm run build` succeeds
- [x] ✅ `npm run check:generated` clean (generated files regenerated, never hand-edited)
- [x] ✅ ESM imports use `.js` extensions
- [x] ✅ No `any` types introduced
- [x] ✅ New code has tests

### 🔄 Breaking Changes

- [x] No breaking changes (all additive; `serena` is optional on the runtime).

### 📝 Reviewer Notes

- Selector is **deterministic** by design (keyword + signal scoring) — no sampler round-trip, consistent with `docs/adr/0001-remove-sampler-round-trip.md`.
- Catalog is **vendored/ported under MIT** with attribution to `Anselmoo/universal-creator` in the modules and docs.
- Deferred: #1605 Phases 6–7 (infra-gated techniques + reusable agents) documented as follow-ups.
- Built via a subagent-driven TDD workflow with per-task + whole-branch review; the whole-branch review caught and fixed a production-wiring gap in the Serena grounding path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)